### PR TITLE
APL logo article

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,10 @@
         >LeetCode 185: Department Top Three Salaries</a>
       <address><time>2022-06-25</time>, Paul Mansour</address></article>
 
+    <article class="Announcement"><a href="https://vector.org.uk/a-vendor-agnostic-logo-for-apl/"
+        >A Vendor-Agnostic Logo for APL</a>
+      <address><time>2022-06-16</time>, Adám Brudzewsky</address></article>
+
     <article class="Idiom"><a href="https://www.toolofthought.com/posts/operators-in-a-dsl"
         >Operators in a DSL</a>
       <address><time>2022-05-28</time>, Paul Mansour</address></article>


### PR DESCRIPTION
Should authors with Wikipedia or APL Wiki pages have their name be a link?