### PR TITLE
Add news entries from ap29600 and loriculus.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,9 +40,49 @@
 <body>
   <h1><span id="ta">The <a tabindex="1" href="https://apl.wiki"><br/><i>APL </i></a></span><span id="tw">Sı̽gn<span id="ta"> of <br/>the </span>Tı̽mes</span><code id="tn"> ×× </code><a tabindex="1" style="font-size:small" href="rss.xml"> RSS FEED</a></h1>
 
+  <article class="Implementation Mathematics">
+    <a href="https://ap29600.github.io/boolean_scans.html">Symmetries in boolean scans</a>
+    2026-08-26, Andrea Piseri
+  </article>
+
+  <article class="Example">
+    <a href="https://loriculus.org/blog/chess-moves-apl/">Chess moves in APL</a>
+    2026-08-16, Rohan Prinja
+  </article>
+
+  <article class="Example Challenge">
+    <a href="https://loriculus.org/blog/validate-sudoku-apl/">Validating a Sudoku board in APL</a>
+    2026-08-12, Rohan Prinja
+  </article>
+
+  <article class="Example">
+    <a href="https://loriculus.org/blog/maximum-nesting-depth/">Maximum nested paren depth in APL</a>
+    2026-08-01, Rohan Prinja
+  </article>
+
   <article class="Design Mathematics">
     <a href="https://butwhyisthat.substack.com/p/ecfp">Extended-Connectivity Fingerprints in APL</a>
     2026-07-22, Manas Mahale
+  </article>
+
+  <article class="Example Idiom">
+    <a href="https://loriculus.org/blog/run-length-encoding-apl/">Run-length encoding in APL</a>
+    2026-07-20, Rohan Prinja
+  </article>
+
+  <article class="Example Idiom">
+    <a href="https://loriculus.org/blog/mask-partition-apl/">Partition arrays with a mask in APL</a>
+    2026-07-19, Rohan Prinja
+  </article>
+
+  <article class="Challenge Example">
+    <a href="https://loriculus.org/blog/apl-problems/">Solutions to some APL problems</a>
+    2026-07-14, Rohan Prinja
+  </article>
+
+  <article class="Idiom">
+    <a href="https://loriculus.org/blog/useful-apl-idioms/">Useful APL snippets</a>
+    2026-07-13, Rohan Prinja
   </article>
 
   <article class="Design Implementation">

--- a/rss.xml
+++ b/rss.xml
@@ -5,6 +5,40 @@
     <atom:link href="https://apl.news/rss.xml" rel="self" type="application/rss+xml"></atom:link>
     <description>APL news aggregator</description>
     <item>
+      <link>https://ap29600.github.io/boolean_scans.html</link>
+      <title>Symmetries in boolean scans</title>
+      <pubDate>Wed, 26 Aug 2026 15:00:00 GMT</pubDate>
+      <description>Andrea Piseri</description>
+      <guid>https://ap29600.github.io/boolean_scans.html</guid>
+      <category>Implementation</category>
+      <category>Mathematics</category>
+    </item>
+    <item>
+      <link>https://loriculus.org/blog/chess-moves-apl/</link>
+      <title>Chess moves in APL</title>
+      <pubDate>Sun, 16 Aug 2026 15:00:00 GMT</pubDate>
+      <description>Rohan Prinja</description>
+      <guid>https://loriculus.org/blog/chess-moves-apl/</guid>
+      <category>Example</category>
+    </item>
+    <item>
+      <link>https://loriculus.org/blog/validate-sudoku-apl/</link>
+      <title>Validating a Sudoku board in APL</title>
+      <pubDate>Wed, 12 Aug 2026 15:00:00 GMT</pubDate>
+      <description>Rohan Prinja</description>
+      <guid>https://loriculus.org/blog/validate-sudoku-apl/</guid>
+      <category>Example</category>
+      <category>Challenge</category>
+    </item>
+    <item>
+      <link>https://loriculus.org/blog/maximum-nesting-depth/</link>
+      <title>Maximum nested paren depth in APL</title>
+      <pubDate>Sat, 01 Aug 2026 15:00:00 GMT</pubDate>
+      <description>Rohan Prinja</description>
+      <guid>https://loriculus.org/blog/maximum-nesting-depth/</guid>
+      <category>Example</category>
+    </item>
+    <item>
       <link>https://butwhyisthat.substack.com/p/ecfp</link>
       <title>Extended-Connectivity Fingerprints in APL</title>
       <pubDate>Wed, 22 Jul 2026 15:00:00 GMT</pubDate>
@@ -12,6 +46,41 @@
       <guid>https://butwhyisthat.substack.com/p/ecfp</guid>
       <category>Design</category>
       <category>Mathematics</category>
+    </item>
+    <item>
+      <link>https://loriculus.org/blog/run-length-encoding-apl/</link>
+      <title>Run-length encoding in APL</title>
+      <pubDate>Mon, 20 Jul 2026 15:00:00 GMT</pubDate>
+      <description>Rohan Prinja</description>
+      <guid>https://loriculus.org/blog/run-length-encoding-apl/</guid>
+      <category>Example</category>
+      <category>Idiom</category>
+    </item>
+    <item>
+      <link>https://loriculus.org/blog/mask-partition-apl/</link>
+      <title>Partition arrays with a mask in APL</title>
+      <pubDate>Sun, 19 Jul 2026 15:00:00 GMT</pubDate>
+      <description>Rohan Prinja</description>
+      <guid>https://loriculus.org/blog/mask-partition-apl/</guid>
+      <category>Example</category>
+      <category>Idiom</category>
+    </item>
+    <item>
+      <link>https://loriculus.org/blog/apl-problems/</link>
+      <title>Solutions to some APL problems</title>
+      <pubDate>Tue, 14 Jul 2026 15:00:00 GMT</pubDate>
+      <description>Rohan Prinja</description>
+      <guid>https://loriculus.org/blog/apl-problems/</guid>
+      <category>Challenge</category>
+      <category>Example</category>
+    </item>
+    <item>
+      <link>https://loriculus.org/blog/useful-apl-idioms/</link>
+      <title>Useful APL snippets</title>
+      <pubDate>Mon, 13 Jul 2026 15:00:00 GMT</pubDate>
+      <description>Rohan Prinja</description>
+      <guid>https://loriculus.org/blog/useful-apl-idioms/</guid>
+      <category>Idiom</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/csv-files-reconsidered</link>


### PR DESCRIPTION
Adds 8 new articles to `index.html` and regenerates `rss.xml` via `Run.aplf` (176 → 184 items).

**From ap29600.github.io** (Andrea Piseri):
- `2026-08-26` — Symmetries in boolean scans (`Implementation Mathematics`)

**From loriculus.org/blog** (Rohan Prinja) — the 7 newest posts with "APL" in the title:
- `2026-08-16` — Chess moves in APL
- `2026-08-12` — Validating a Sudoku board in APL
- `2026-08-01` — Maximum nested paren depth in APL
- `2026-07-20` — Run-length encoding in APL
- `2026-07-19` — Partition arrays with a mask in APL
- `2026-07-14` — Solutions to some APL problems
- `2026-07-13` — Useful APL snippets

Note: the *APL Problem Solving Competition 2023* post was requested too, but it is already listed (2023-08-11), so it was not re-added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)