### PR TITLE
Rework tag taxonomy into a balanced 11-tag set

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,592 +40,592 @@
 <body>
   <h1><span id="ta">The <a tabindex="1" href="https://apl.wiki"><br/><i>APL </i></a></span><span id="tw">Sı̽gn<span id="ta"> of <br/>the </span>Tı̽mes</span><code id="tn"> ×× </code><a tabindex="1" style="font-size:small" href="rss.xml"> RSS FEED</a></h1>
 
-  <article class="Implementation Mathematics">
+  <article class="Idioms-Techniques Interpreter-Internals Numeric-Math">
     <a href="https://ap29600.github.io/boolean_scans.html">Symmetries in boolean scans</a>
     2026-08-26, Andrea Piseri
   </article>
 
-  <article class="Example">
+  <article class="Puzzle-Solving Tutorial">
     <a href="https://loriculus.org/blog/chess-moves-apl/">Chess moves in APL</a>
     2026-08-16, Rohan Prinja
   </article>
 
-  <article class="Example Challenge">
+  <article class="Tutorial Puzzle-Solving">
     <a href="https://loriculus.org/blog/validate-sudoku-apl/">Validating a Sudoku board in APL</a>
     2026-08-12, Rohan Prinja
   </article>
 
-  <article class="Example">
+  <article class="Puzzle-Solving Tutorial Idioms-Techniques">
     <a href="https://loriculus.org/blog/maximum-nesting-depth/">Maximum nested paren depth in APL</a>
     2026-08-01, Rohan Prinja
   </article>
 
-  <article class="Design Mathematics">
+  <article class="Tutorial Numeric-Math Cross-Language">
     <a href="https://butwhyisthat.substack.com/p/ecfp">Extended-Connectivity Fingerprints in APL</a>
     2026-07-22, Manas Mahale
   </article>
 
-  <article class="Example Idiom">
+  <article class="Tutorial Idioms-Techniques Cross-Language">
     <a href="https://loriculus.org/blog/run-length-encoding-apl/">Run-length encoding in APL</a>
     2026-07-20, Rohan Prinja
   </article>
 
-  <article class="Example Idiom">
+  <article class="Tutorial Idioms-Techniques">
     <a href="https://loriculus.org/blog/mask-partition-apl/">Partition arrays with a mask in APL</a>
     2026-07-19, Rohan Prinja
   </article>
 
-  <article class="Challenge Example">
+  <article class="Puzzle-Solving Idioms-Techniques">
     <a href="https://loriculus.org/blog/apl-problems/">Solutions to some APL problems</a>
     2026-07-14, Rohan Prinja
   </article>
 
-  <article class="Idiom">
+  <article class="Idioms-Techniques">
     <a href="https://loriculus.org/blog/useful-apl-idioms/">Useful APL snippets</a>
     2026-07-13, Rohan Prinja
   </article>
 
-  <article class="Design Implementation">
+  <article class="Opinion Data-Query Language-Design">
     <a href="https://www.toolofthought.com/posts/csv-files-reconsidered">CSV Files Reconsidered</a>
     2026-05-21, Paul Mansour
   </article>
 
-  <article class="Design Example">
+  <article class="Opinion Idioms-Techniques">
     <a href="https://www.toolofthought.com/posts/apl-makes-us-smile">APL Makes Us Smile</a>
     2026-05-21, Paul Mansour
   </article>
 
-  <article class="Example Design">
+  <article class="Tutorial Idioms-Techniques">
     <a href="https://maxcan-code.github.io/blog/2026/05/19/power-user-apl.html">Power User APL</a>
     2026-05-19, Max Sun 
   </article>
 
-  <article class="Design Mathematics">
+  <article class="Opinion Web-GUI">
     <a href="https://homewithinnowhere.com/posts/2026-05-10-one-line.html">Saying Goodbye to one line of APL</a>
     2026-05-10, Kyle Croarkin
   </article>
 
-  <article class="Commentary Language-comparison">
+  <article class="Cross-Language Data-Query">
     <a href="https://www.toolofthought.com/posts/a-query-in-r">A Query in R and Kap</a>
     2026-05-08, Paul Mansour
   </article>
 
-  <article class="Language-comparison Example">
+  <article class="Cross-Language Data-Query">
     <a href="https://blog.dhsdevelopments.com/a-little-comparison-between-r-and-kap">A little comparison between R and Kap</a>
     2026-05-02, Elias Mårtenson
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals">
     <a href="https://blog.dhsdevelopments.com/kap-performance">Kap performance</a>
     2026-04-13, Elias Mårtenson
   </article>
 
-  <article class="Implementation">
+  <article class="Announcement Web-GUI">
     <a href="https://blog.dhsdevelopments.com/new-gui-for-kap">New GUI for Kap</a>
     2026-04-02, Elias Mårtenson
   </article>
 
-  <article class="Example Design">
+  <article class="Tutorial Web-GUI">
     <a href="https://homewithinnowhere.com/blog/voxel_game/">Notes on writing a voxel game in Dyalog APL</a>
     2026-03-06, Kyle Croarkin
   </article>
 
-  <article class="Mathematics">
+  <article class="Numeric-Math Tutorial">
     <a href="https://blog.wilsonb.com/posts/2026-02-27-easy-random-trees.html">Easy Random Trees</a>
     2026-02-27, Brandon Wilson
   </article>
 
-  <article class="Commentary">
+  <article class="Opinion Puzzle-Solving">
     <a href="https://blog.veitheller.de/A_quick_apology_to_Dyalog_APL.html">A quick apology to Dyalog APL</a>
     2026-01-31, Veit Heller
   </article>
 
-  <article class="Example Language-comparison">
+  <article class="Tutorial Puzzle-Solving">
     <a href="https://blog.veitheller.de/Simple_Sudoku_Solvers_SII,_EI:_Dyalog_APL.html">Simple Sudoku Solvers SII, EI: Dyalog APL</a>
     2026-01-20, Veit Heller
   </article>
 
-  <article class="Example Pointfree">
+  <article class="Idioms-Techniques">
     <a href="https://www.toolofthought.com/posts/variation-on-iota">Variation on Iota</a>
     2025-11-12, Paul Mansour
   </article>
 
-  <article class="Example Challenge">
+  <article class="Idioms-Techniques Numeric-Math">
     <a href="https://www.sacrideo.us/multi-dimensional-weighted-random-roll-choice-dice-selection/">Multi-dimensional weighted random roll (choice, dice, selection)</a>
     2025-08-30, Aaron Hsu
   </article>
 
-  <article class="Example Commentary">
+  <article class="Opinion Idioms-Techniques">
     <a href="https://www.toolofthought.com/posts/on-arguments">On Arguments</a>
     2025-08-15, Paul Mansour
   </article>
 
-  <article class="Example">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/menus-revisited">Menus Revisited</a>
     2025-08-09, Paul Mansour
   </article>
 
-  <article class="Example Commentary">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/input-components">Input Components</a>
     2025-08-06, Paul Mansour
   </article>
 
-  <article class="Example">
+  <article class="Web-GUI Tutorial Language-Design">
     <a href="https://www.toolofthought.com/posts/whats-on-the-menu">What's on the Menu?</a>
     2025-06-21, Paul Mansour
   </article>
 
-  <article class="Challenge">
+  <article class="Puzzle-Solving Tutorial">
     <a href="https://pitr.ca/2025-06-14-queens">Solving LinkedIn Queens with APL</a>
     2025-06-14, Peter Vernigorov
   </article>
 
-  <article class="Commentary">
+  <article class="Opinion Cross-Language">
     <a href="https://www.toolofthought.com/posts/grok-as-apl-interpreter">Grok as APL Interpreter</a>
     2025-06-04, Paul Mansour
   </article>
 
-  <article class="Implementation Design">
+  <article class="Announcement Interpreter-Internals Language-Design">
     <a href="https://blog.rubenverg.com/tinyapl_15_extra_arguments">TinyAPL part 15: Extra Arguments</a>
     2025-03-13, Madeline Vergani
   </article>
 
-  <article class="Example Commentary">
+  <article class="Tutorial Cross-Language">
     <a href="https://blog.dhsdevelopments.com/finding-words-using-kap">Finding words using Kap</a>
     2025-02-25, Elias Mårtenson
   </article>
 
-  <article class="Challenge">
+  <article class="Tutorial Data-Query Cross-Language">
     <a href="https://blog.dhsdevelopments.com/axis-labels-in-kap">Axis labels in Kap</a>
     2025-02-17, Elias Mårtenson
   </article>
 
-  <article class="Example Commentary">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/html-tables-revisited">HTML Tables Revisited</a>
     2025-02-16, Paul Mansour
   </article>
 
-  <article class="Design Commentary">
+  <article class="Language-Design Opinion">
     <a href="https://www.toolofthought.com/posts/rethinking-vset-and-vget">Rethinking ⎕VSET and ⎕VGET</a>
     2025-02-05, Paul Mansour
   </article>
 
-  <article class="Language-comparison">
+  <article class="Tutorial Language-Design">
     <a href="https://www.toolofthought.com/posts/version-20-goodies">Version 20 Goodies</a>
     2025-01-31, Paul Mansour
   </article>
 
-  <article class="Language-comparison">
+  <article class="Opinion Language-Design">
     <a href="https://www.toolofthought.com/posts/new-tricks-for-old-dogs">New Tricks for Old Dogs</a>
     2025-01-29, Paul Mansour
   </article>
 
-  <article class="Challenge">
+  <article class="Puzzle-Solving Tutorial">
     <a href="https://blog.dhsdevelopments.com/advent-of-code-2024-part-2">Advent of Code 2024 day 1, part 2</a>
     2025-01-12, Elias Mårtenson
   </article>
 
-  <article class="Example">
+  <article class="Opinion Web-GUI">
     <a href="https://www.toolofthought.com/posts/html-templates">HTML Templates</a>
     2025-01-07, Paul Mansour
   </article>
 
-  <article class="Challenge">
+  <article class="Puzzle-Solving Tutorial">
     <a href="https://blog.dhsdevelopments.com/advent-of-code-2024">Advent of code 2024</a>
     2024-12-28, Elias Mårtenson
   </article>
 
-  <article class="Mathematics Challenge">
+  <article class="Puzzle-Solving Numeric-Math">
     <a href="https://blog.wilsonb.com/posts/2024-12-14-aoc-14.html">Advent of Code 2024, Day 14</a>
     2024-12-14, Brandon Wilson
   </article>
 
-  <article class="Mathematics Challenge">
+  <article class="Puzzle-Solving Numeric-Math">
     <a href="https://blog.wilsonb.com/posts/2024-12-14-aoc-13.html">Advent of Code 2024, Day 13</a>
     2024-12-14, Brandon Wilson
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals Language-Design">
     <a href="https://blog.rubenverg.com/tinyapl_14_dictionaries">TinyAPL part 14: (Wrap Your Head Around) Dictionaries</a>
     2024-11-30, Madeline Vergani
   </article>
 
-  <article class="Vintage Announcement Example">
+  <article class="Announcement Interpreter-Internals">
     <a href="https://medium.com/@solarbreeze69/presenting-queztcoapl-2cdc1b9d234b">Presenting QueztcoAPL!</a>
     2024-11-28, solarbreeze
   </article>
 
-  <article class="Language-comparison Idiom">
+  <article class="Cross-Language Idioms-Techniques">
     <a href="https://jcarroll.com.au/2024/11/28/these-languages-are-accumulating/">These Languages are Accumulating</a>
     2024-11-28, Jonathan Carroll
   </article>
 
-  <article class="Education Example">
+  <article class="Tutorial Idioms-Techniques">
     <a href="https://www.toolofthought.com/posts/find-and-replace-with-interval-index">Find and Replace with Interval Index</a>
     2024-11-07, Paul Mansour
   </article>
 
-  <article class="Design Language-comparison Education">
+  <article class="Tutorial Idioms-Techniques">
     <a href="https://blog.dhsdevelopments.com/an-imperative-introduction-to-array-programming">An imperative introduction to array programming</a>
     2024-10-30, Elias Mårtenson
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals Language-Design">
     <a href="https://blog.rubenverg.com/tinyapl_13_biggest_mistake_biggest_change">TinyAPL part 13: The Biggest Mistake, The Biggest Change</a>
     2024-10-27, Madeline Vergani
   </article>
 
-  <article class="Language-comparison Challenge">
+  <article class="Cross-Language Puzzle-Solving">
     <a href="https://jcarroll.com.au/2024/10/26/polyglot-maxxie-and-minnie/">Polyglot Maxxie and Minnie</a>
     2024-10-26, Jonathan Carroll
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals Language-Design">
     <a href="https://blog.rubenverg.com/tinyapl_12_at_depth_ordering">TinyAPL part 12: At Depth and Ordering</a>
     2024-10-02, Madeline Vergani
   </article>
 
-  <article class="Example Design">
+  <article class="Tutorial Interpreter-Internals">
     <a href="https://blog.wilsonb.com/posts/2024-09-27-brainfuck.html">Implementing Brainfuck</a>
     2024-09-27, Brandon Wilson
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals Language-Design">
     <a href="https://blog.rubenverg.com/tinyapl_11_bases_searching">TinyAPL part 11: Bases and Searching</a>
     2024-09-13, Madeline Vergani
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals Language-Design">
     <a href="https://blog.rubenverg.com/tinyapl_10_wraps_structs_stdlib">TinyAPL part 10: Wraps, Structs, a Standard Library</a>
     2024-09-03, Madeline Vergani
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals Idioms-Techniques Language-Design">
     <a href="https://blog.rubenverg.com/tinyapl_9_more_tacit">TinyAPL part 9: More Tacit!</a>
     2024-08-10, Madeline Vergani
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals Web-GUI">
     <a href="https://blog.rubenverg.com/tinyapl_8_rank_web">TinyAPL part 8: All About Rank, and a Web Interface</a>
     2024-08-03, Madeline Vergani
   </article>
 
-  <article class="Implementation">
+  <article class="Language-Design Interpreter-Internals">
     <a href="https://www.toolofthought.com/posts/rumba-threading-model">Rumba Threading Model</a>
     2024-07-28, Paul Mansour
   </article>
 
-  <article class="Implementation">
+  <article class="Announcement Interpreter-Internals">
     <a href="https://www.toolofthought.com/posts/revisiting-rumba">Revisiting Rumba</a>
     2024-07-17, Paul Mansour
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals Language-Design">
     <a href="https://blog.rubenverg.com/tinyapl_7_quads_key_index">TinyAPL part 7: Quads, Key, Index</a>
     2024-05-30, Madeline Vergani
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals">
     <a href="https://blog.rubenverg.com/tinyapl_6_tests_docs_each">TinyAPL part 6: Tests, Docs, Each</a>
     2024-05-21, Madeline Vergani
   </article>
 
-  <article class="Example">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/a-high-performance-data-grid-in-html">A High Performance Data Grid in HTML</a>
     2024-05-20, Paul Mansour
   </article>
 
-  <article class="Example">
+  <article class="Tutorial Web-GUI">
     <a href="https://www.toolofthought.com/posts/modal-dialog-boxes-progressbar-more">Modal Dialog Boxes 5: More on ProgressBar</a>
     2024-05-18, Paul Mansour
   </article>
 
-  <article class="Example">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/modal-dialog-boxes-progressbar">Modal Dialog Boxes 4: ProgressBar</a>
     2024-05-14, Paul Mansour
   </article>
 
-  <article class="Commentary Testing">
+  <article class="Opinion">
     <a href="https://www.toolofthought.com/posts/uncle-bob-and-the-primeagen">Uncle Bob and The Primeagen</a>
     2024-05-07, Paul Mansour
   </article>
 
-  <article class="Example">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/modal-dialog-boxes-prompt">Modal Dialog Boxes 3: Prompt</a>
     2024-05-06, Paul Mansour
   </article>
 
-  <article class="Example">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/modal-dialog-boxes-confirm">Modal Dialog Boxes 2: Confirm</a>
     2024-04-30, Paul Mansour
   </article>
 
-  <article class="Example">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/modal-dialog-boxes-1">Modal Dialog Boxes 1: Alert</a>
     2024-04-29, Paul Mansour
   </article>
 
-  <article class="Mathematics">
+  <article class="Tutorial Numeric-Math">
     <a href="https://bl0v3.com/Blog/raymarching-in-dyalog-apl/">Raymarching meets dyalog APL</a>
     2024-04-28, bl0v3
   </article>
 
-  <article class="Example">
+  <article class="Web-GUI Interpreter-Internals">
     <a href="https://www.toolofthought.com/posts/abacus-threading-model">The Abacus Threading Model</a>
     2024-04-28, Paul Mansour
   </article>
 
-  <article class="Example Mathematics">
+  <article class="Numeric-Math">
     <a href="https://grahamenos.com/apl-min-plus.html">Tropical Semiring in Dyalog APL</a>
     2024-04-04, Graham Enos
   </article>
 
-  <article class="Announcement Anecdote Commentary">
+  <article class="Announcement Puzzle-Solving">
     <a href="https://www.dyalog.com/blog/2024/03/the-apl-quest-series/">The APL Quest Series</a>
     2024-03-15, Adám Brudzewsky
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals Language-Design">
     <a href="https://blog.rubenverg.com/tinyapl_5_array_notation_reductions">TinyAPL part 5: Array Notation and Reductions</a>
     2024-03-14, Madeline Vergani
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals">
     <a href="https://blog.rubenverg.com/tinyapl_4_parsing">TinyAPL part 4: Finally, Parsing!</a>
     2024-03-11, Madeline Vergani
   </article>
 
-  <article class="Design Implementation Language-comparison">
+  <article class="Opinion Cross-Language">
     <a href="https://blog.dhsdevelopments.com/array-languages-vs">Array languages vs. the curse of the spreadsheet</a>
     2024-02-25, Elias Mårtenson
   </article>
 
-  <article class="Mathematics">
+  <article class="Tutorial Numeric-Math">
     <a href="https://palaiologos.rocks/posts/polygon-triangulation/">Triangulation of convex polygons</a>
     2024-02-23, Kamila Szewczyk
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals Cross-Language">
     <a href="https://scharenbroch.dev/projects/apl-interpreter/">APL Interpreter</a>
     2024-01-11, Lucas Scharenbroch
   </article>
 
-  <article class="Language-comparison Example Commentary">
+  <article class="Opinion Language-Design Cross-Language">
     <a href="https://github.com/justin2004/weblog/blob/master/design_implications/README.md">Design Implications (Python &amp; APL)</a>
     2024-01-09, Justin Dowdy
   </article>
 
-  <article class="Vintage Challenge Language-comparison">
+  <article class="Puzzle-Solving Cross-Language">
     <a href="https://medium.com/@solarbreeze69/exploring-the-apl-one-liner-solutions-to-logikers-christmas-challenge-2023-on-the-commodore-64-b027e6ee486b">Exploring the APL One-Liner Solutions to Logiker’s Christmas Challenge on the Commodore 64</a>
     2024-01-05, solarbreeze
   </article>
 
-  <article class="Vintage Challenge">
+  <article class="Puzzle-Solving">
     <a href="https://medium.com/@solarbreeze69/two-apl-solutions-to-logikers-vintage-computing-christmas-challenge-2023-014feacc8a8f">Two APL Solutions to Logiker’s Vintage Computing Christmas Challenge 2023</a>
     2023-12-27, solarbreeze
   </article>
 
-  <article class="Design Implementation">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/making-sharpplot-charts-interactive">Making SharpPlot Charts Interactive</a>
     2023-12-21, Paul Mansour
   </article>
 
-  <article class="Challenge">
+  <article class="Puzzle-Solving Tutorial Numeric-Math">
     <a href="https://xpqz.github.io/Advent-of-Code-day-8/">Advent Of Code Day 8: Haunted Wasteland</a>
     2023-12-11, Stefan Kruger
   </article>
 
-  <article class="Language-comparison">
+  <article class="Puzzle-Solving Cross-Language">
     <a href="https://jcarroll.com.au/2023/12/10/advent-of-array-elegance/">Advent of Array Elegance (AoC2023 Day 7)</a>
     2023-12-10, Jonathan Carroll
   </article>
 
-  <article class="Mathematics">
+  <article class="Tutorial Data-Query Numeric-Math">
     <a href="https://www.toolofthought.com/posts/on-categorical-data">On Categorical Data</a>
     2023-12-06, Paul Mansour
   </article>
 
-  <article class="Challenge">
+  <article class="Puzzle-Solving Tutorial Idioms-Techniques">
     <a href="https://xpqz.github.io/Advent-of-Code-Day-3/">Advent Of Code Day 3: Gear Ratios</a>
     2023-12-05, Stefan Kruger
   </article>
 
-  <article class="Challenge">
+  <article class="Puzzle-Solving Tutorial">
     <a href="https://xpqz.github.io/AoC-day1/">Advent of Code Day 1</a>
     2023-12-01, Stefan Kruger
   </article>
 
-  <article class="Education">
+  <article class="Tutorial Idioms-Techniques">
     <a href="https://scharenbroch.dev/blog/apl-tutorial/">APL Tutorial</a>
     2023-11-27, Lucas Scharenbroch
   </article>
 
-  <article class="Implementation">
+  <article class="Interpreter-Internals Tutorial">
     <a href="https://blog.rubenverg.com/tinyapl_3_more_primitives">TinyAPL part 3: More Primitives</a>
     2023-11-21, Madeline Vergani
   </article>
 
-  <article class="Commentary Design">
+  <article class="Opinion Data-Query Language-Design">
     <a href="https://www.toolofthought.com/posts/high-rank-arrays">High-Rank Arrays</a>
     2023-11-15, Paul Mansour
   </article>
 
-  <article class="Design">
+  <article class="Language-Design Interpreter-Internals">
     <a href="https://blog.dhsdevelopments.com/n-tuples-and-the-introduction-of-null-values-in-kap">N-tuples and the Introduction of Null values in Kap</a>
     2023-11-06, Elias Mårtenson
   </article>
 
-  <article class="Language-comparison">
+  <article class="Cross-Language Puzzle-Solving">
     <a href="https://jcarroll.com.au/2023/10/09/hooray-array/">Hooray, Array!</a>
     2023-10-09, Jonathan Carroll
   </article>
 
-  <article class="Mathematics Anecdote">
+  <article class="Puzzle-Solving Announcement">
     <a href="https://palaiologos.rocks/posts/dan-baronets-microwave/">Dan Baronet’s Microwave</a>
     2023-10-04, Kamila Szewczyk
   </article>
 
-  <article class="Vintage Implementation">
+  <article class="Announcement">
     <a href="https://medium.com/@solarbreeze69/draculark-a-mudlarking-vampire-hunting-game-bbf40361bf1a">DRACULARK: a Mudlarking &amp; Vampire Hunting Game</a>
     2023-09-29, solarbreeze
   </article>
 
-  <article class="Commentary">
+  <article class="Web-GUI Data-Query">
     <a href="https://www.toolofthought.com/posts/charting-and-tidy-data">Charting and Tidy Data</a>
     2023-09-28, Paul Mansour
   </article>
   
-  <article class="Design">
+  <article class="Web-GUI Opinion">
     <a href="https://www.toolofthought.com/posts/project-playfair">Project Playfair</a>
     2023-09-27, Paul Mansour
   </article>
   
-  <article class="Example">
+  <article class="Tutorial Idioms-Techniques">
     <a href="https://www.toolofthought.com/posts/ordered-namespaces">Ordered Namespaces</a>
     2023-09-26, Paul Mansour
   </article>  
   
-  <article class="Design Implementation">
+  <article class="Interpreter-Internals Tutorial">
     <a href="https://blog.rubenverg.com/tinyapl_2_functions_operators">TinyAPL part 2: Functions &amp; Operators</a>
     2023-09-23, Madeline Vergani
   </article>
 
-  <article class="Design">
+  <article class="Web-GUI Language-Design">
     <a href="https://www.toolofthought.com/posts/towards-a-chart-wizard">Towards a Chart Wizard</a>
     2023-09-20, Paul Mansour
   </article>
 
-  <article class="Design Humour">
+  <article class="Language-Design Opinion Puzzle-Solving">
     <a href="https://blog.rubenverg.com/float_indexing">Extending indices to floating-point values</a>
     2023-09-01, Madeline Vergani
   </article>
 
-  <article class="Language-comparison">
+  <article class="Cross-Language Opinion">
     <a href="https://jcarroll.com.au/2023/08/29/now-you-re-thinking-with-arrays/">Now You're Thinking with Arrays</a>
     2023-08-29, Jonathan Carroll
   </article>
 
-  <article class="Mathematics">
+  <article class="Numeric-Math Tutorial">
     <a href="https://blog.wilsonb.com/posts/2023-08-29-mundane-exotic-number-system.html">A Mundane Exotic Number System</a>
     2023-08-29, Brandon Wilson
   </article>
 
-  <article class="Testing">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/testing-guis-wrestling-with-events">Testing GUIs: Wrestling with Events</a>
     2023-08-18, Paul Mansour
   </article>
 
-  <article class="Example Anecdote Language-comparison">
+  <article class="Cross-Language Opinion Idioms-Techniques">
     <a href="https://mathspp.com/blog/what-learning-apl-taught-me-about-python">What learning APL taught me about Python</a>
     2023-08-15, Rodrigo Girão Serrão
   </article>
 
-  <article class="Testing">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/testing-guis">Testing GUIs</a>
     2023-08-14, Paul Mansour
   </article>
   
-  <article class="Mathematics Challenge">
+  <article class="Numeric-Math Puzzle-Solving">
     <a href="https://palaiologos.rocks/posts/avg/">The nested means problem</a>
     2023-08-13, Kamila Szewczyk
   </article>
 
-  <article class="Implementation Mathematics">
+  <article class="Interpreter-Internals Numeric-Math">
     <a href="https://palaiologos.rocks/posts/lc-apl/">Journey to the Center of the Lambda Calculus</a>
     2023-08-13, Kamila Szewczyk
   </article>
 
-  <article class="Commentary Example">
+  <article class="Puzzle-Solving">
     <a href="https://ap29600.github.io/apl_problemsolving_23.html">APL Problem Solving Competition 2023</a>
     2023-08-11, Andrea Piseri
   </article>
 
-  <article class="Design Implementation">
+  <article class="Interpreter-Internals Tutorial Language-Design">
     <a href="https://blog.rubenverg.com/tinyapl_1_arrays">TinyAPL part 1: Introduction &amp; Arrays</a>
     2023-08-05, Madeline Vergani
   </article>
 
-  <article class="Example Commentary Challenge">
+  <article class="Idioms-Techniques Numeric-Math">
     <a href="https://blog.wilsonb.com/posts/2023-08-04-what-does-grade-grade-even-mean.html">What Does ⍋⍋ Even Mean?</a>
     2023-08-04, Brandon Wilson
   </article>
 
-  <article class="Example Commentary Idiom">
+  <article class="Idioms-Techniques Opinion">
     <a href="https://blog.rubenverg.com/suggestivity_and_idioms">On Wilson's "On Hsu's Suggestivity and Idioms"</a>
     2023-07-27, Madeline Vergani
   </article>
 
-  <article class="Example Commentary Idiom">
+  <article class="Idioms-Techniques Language-Design Opinion">
     <a href="https://blog.wilsonb.com/posts/2023-07-24-suggestivity-and-idioms.html">On Hsu's Suggestivity and Idioms</a>
     2023-07-24, Brandon Wilson
   </article>
 
-  <article class="Vintage">
+  <article class="Opinion">
     <a href="https://medium.com/@solarbreeze69/superpet-apl-trek-493689243f05">SuperPET APL Trek</a>
     2023-07-18, solarbreeze
   </article>
 
-  <article class="Language-comparison">
+  <article class="Cross-Language Tutorial">
     <a href="https://jcarroll.com.au/2023/07/07/array-languages-r-vs-apl/">Array Languages: R vs APL</a>
     2023-07-07, Jonathan Carroll
   </article>
 
-  <article class="Example Commentary Idiom">
+  <article class="Idioms-Techniques">
     <a href="https://www.toolofthought.com/posts/boolean-techniques">Boolean Techniques</a>
     2023-05-13, Paul Mansour
   </article>
 
-  <article class="Design">
+  <article class="Opinion">
     <a href="https://www.toolofthought.com/posts/dont-trap-when-you-can-verify">Don't Trap When You Can Verify</a>
     2023-05-11, Paul Mansour
   </article>
 
-  <article class="Challenge Commentary">
+  <article class="Tutorial Numeric-Math">
     <a href="https://www.toolofthought.com/posts/excel-column-names">Excel Column Names</a>
     2023-05-08, Paul Mansour
   </article>
 
-  <article class="Example Idiom">
+  <article class="Idioms-Techniques Opinion">
     <a href="https://www.sacrideo.us/suggestivity-and-idioms-in-apl/">Suggestivity and Idioms in APL</a>
     2023-05-02, Aaron Hsu
   </article>
 
-  <article class="Commentary">
+  <article class="Opinion">
     <a href="https://www.sacrideo.us/flat-program-organization-an-email-response/">Flat Program Organization: An Email Response</a>
     2023-04-21, Aaron Hsu
   </article>
 
-  <article class="Design Announcement">
+  <article class="Language-Design Announcement">
     <a href="https://www.dyalog.com/blog/2023/04/formal-proposal-for-apl-array-notation-seeking-feedback">Formal Proposal for APL Array Notation – Seeking Feedback</a>
     2023-04-21, Morten Kromberg
   </article>
 
-  <article class="Example">
+  <article class="Web-GUI Interpreter-Internals">
     <a href="https://www.toolofthought.com/posts/dom-via-json-performance">DOM via JSON Performance</a>
     2023-04-12, Paul Mansour
   </article>
 
-  <article class="Example">
+  <article class="Tutorial Web-GUI">
     <a href="https://www.toolofthought.com/posts/the-dom-via-json">The DOM via JSON</a>
     2023-04-11, Paul Mansour
   </article>
@@ -635,7 +635,7 @@
     2023-04-11, Morten Kromberg
   </article>
 
-  <article class="Design Announcement">
+  <article class="Announcement Language-Design">
     <a href="https://www.dyalog.com/blog/2023/04/extending-structural-functions-to-scalars">Extending Structural Functions to Scalars</a>
     2023-04-01, Morten Kromberg
   </article>
@@ -645,152 +645,152 @@
     2023-03-30, Dyalog
   </article>
 
-  <article class="Example">
+  <article class="Numeric-Math Data-Query Idioms-Techniques">
     <a href="https://www.toolofthought.com/posts/validating-dates">Validating Dates</a>
     2023-03-27, Paul Mansour
   </article>
 
-  <article class="Example Challenge">
+  <article class="Idioms-Techniques Numeric-Math">
     <a href="https://www.toolofthought.com/posts/grade-up-of-grade-down">Grade Down of Grade Up</a>
     2023-03-21, Paul Mansour
   </article>
 
-  <article class="Announcement Commentary">
+  <article class="Announcement Puzzle-Solving">
     <a href="https://www.sacrideo.us/2023-apl-problem-solving-competition">2023 APL Problem Solving Competition</a>
     2023-03-10, Aaron Hsu
   </article>
 
-  <article class="Design Idiom">
+  <article class="Opinion Idioms-Techniques">
     <a href="https://www.toolofthought.com/posts/how-would-you-write-this">How Would You Write This?</a>
     2023-03-05, Paul Mansour
   </article>
 
-  <article class="Commentary">
+  <article class="Opinion">
     <a href="https://razetime.github.io/blog/2023/03/02/apl-assumptions.html">Common misconceptions about APL</a>
     2023-03-02, Raghu Ranganathan
   </article>
 
-  <article class="Announcement">
+  <article class="Announcement Data-Query">
     <a href="https://www.toolofthought.com/posts/text2date">Text2Date, a New Repository</a>
     2023-02-27, Paul Mansour
   </article>
 
-  <article class="Example">
+  <article class="Tutorial">
     <a href="https://www.toolofthought.com/posts/error-trapping">Error Trapping</a>
     2023-02-20, Paul Mansour
   </article>
 
-  <article class="Design">
+  <article class="Announcement">
     <a href="https://www.toolofthought.com/posts/provanto">Provanto: A Test Framework</a>
     2023-02-13, Paul Mansour
   </article>
 
-  <article class="Design Example">
+  <article class="Language-Design Announcement">
     <a href="https://blog.dhsdevelopments.com/returning-from-functions-in-kap">Returning from functions in KAP</a>
     2023-02-04, Elias Mårtenson
   </article>
 
-  <article class="Design">
+  <article class="Opinion Language-Design">
     <a href="https://www.dyalog.com/blog/2023/01/structural-vs-mathematical-under">Structural vs. Mathematical “Under”</a>
     2023-01-26, Morten Kromberg
   </article>
 
-  <article class="Example">
+  <article class="Tutorial Data-Query Opinion">
     <a href="https://www.toolofthought.com/posts/text-to-date">Converting Text to Date</a>
     2023-01-23, Paul Mansour
   </article>
 
-  <article class="Example">
+  <article class="Tutorial Cross-Language">
     <a href="https://mathspp.com/blog/connecting-python-and-dyalog-apl-with-sockets">Connecting Python and Dyalog APL with sockets</a>
     2023-01-21, Rodrigo Girão Serrão
   </article>
 
-  <article class="Design">
+  <article class="Tutorial Idioms-Techniques">
     <a href="https://www.toolofthought.com/posts/an-issue-with-xml-revisited">An Issue With ⎕XML Revisited</a>
     2023-01-09, Paul Mansour
   </article>
 
-  <article class="Vintage Challenge">
+  <article class="Puzzle-Solving">
     <a href="https://medium.com/@solarbreeze69/an-apl-solution-to-logikers-vintage-computing-christmas-challenge-2022-d8d9751e6eb6">An APL Solution to Logiker’s Vintage Computing Christmas Challenge 2022</a>
     2022-12-28, solarbreeze
   </article>
 
-  <article class="Example Idiom">
+  <article class="Data-Query Tutorial">
     <a href="https://www.toolofthought.com/posts/anatomy-of-a-query-iii">Anatomy of a Query, Part 3</a>
     2022-12-27, Paul Mansour
   </article>
 
-  <article class="Example Idiom">
+  <article class="Data-Query Tutorial">
     <a href="https://www.toolofthought.com/posts/anatomy-of-a-query-ii">Anatomy of a Query, Part 2</a>
     2022-12-20, Paul Mansour
   </article>
 
-  <article class="Challenge">
+  <article class="Tutorial Numeric-Math">
     <a href="https://www.toolofthought.com/posts/secret-santa">Secret Santa</a>
     2022-12-12, Paul Mansour
   </article>
 
-  <article class="Challenge">
+  <article class="Puzzle-Solving Tutorial">
     <a href="https://blog.dhsdevelopments.com/kap-solution-to-day-2-of-advent-of-code">KAP solution to day 2 of Advent of Code</a>
     2022-12-04, Elias Mårtenson
   </article>
   
-  <article class="Example">
+  <article class="Numeric-Math Tutorial">
     <a href="https://razetime.github.io/blog/2022/12/01/apl-willans.html">Willans' Formula in APL</a>
     2022-12-01, Raghu Ranganathan
   </article>
 
-  <article class="Example">
+  <article class="Tutorial Web-GUI">
     <a href="https://www.toolofthought.com/posts/parsing-markdown">Parsing Markdown</a>
     2022-10-24, Paul Mansour
   </article>
 
-  <article class="Example Idiom">
+  <article class="Data-Query Tutorial">
     <a href="https://www.toolofthought.com/posts/anatomy-of-a-query">Anatomy of a Query, Part 1</a>
     2022-10-23, Paul Mansour
   </article>
 
-  <article class="Announcement Commentary">
+  <article class="Announcement">
     <a href="https://optima-systems.co.uk/dyalog22-apl-user-meeting-portugal">Dyalog’22 APL User Meeting, Portugal</a>
     2022-10-19, Paul Grosvenor
   </article>
 
-  <article class="Example">
+  <article class="Idioms-Techniques Web-GUI">
     <a href="https://www.toolofthought.com/posts/composerules-revisited">ComposeRules Revisited</a>
     2022-10-07, Paul Mansour
   </article>
 
-  <article class="Example">
+  <article class="Tutorial Numeric-Math">
     <a href="https://razetime.github.io/blog/2022/10/03/apl-balanced-trees.html">Some balanced binary trees in APL</a>
     2022-10-03, Raghu Ranganathan
   </article>
 
-  <article class="Commentary">
+  <article class="Language-Design Cross-Language Opinion">
     <a href="https://futhark-lang.org/blog/2022-10-03-futhark-on-arraycast.html">Futhark on The Array Cast</a>
     2022-10-03, Troels Henriksen
   </article>
 
-  <article class="Example">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/constructing-css-in-apl">Constructing CSS in APL</a>
     2022-09-30, Paul Mansour
   </article>
 
-  <article class="Example">
+  <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/threading-the-htmlrenderer">Threading the HTMLRenderer</a>
     2022-09-22, Paul Mansour
   </article>
 
-  <article class="Example Design">
+  <article class="Web-GUI Tutorial Language-Design">
     <a href="https://www.toolofthought.com/posts/a-document-object-model-in-apl">A Document Object Model in APL</a>
     2022-09-21, Paul Mansour
   </article>
 
-  <article class="Commentary">
+  <article class="Opinion Idioms-Techniques Cross-Language">
     <a href="http://blog.vmchale.com/article/apl-different">APL Is Truly Different</a>
     2022-08-26, Vanessa McHale
   </article>
 
-  <article class="Anecdote">
+  <article class="Cross-Language Tutorial Data-Query">
     <a href="https://www.dyalog.com/blog/2022/08/maintaining-pynapl-part-2-apl-arrays-python-objects-and-json">Maintaining Py’n’APL Part 2: APL Arrays, Python Objects, and JSON</a>
     2022-08-24, Rodrigo Girão Serrão
   </article>
@@ -800,52 +800,52 @@
     2022-08-11, APL2000
   </article>
 
-  <article class="Example Challenge">
+  <article class="Tutorial Numeric-Math">
     <a href="https://isaac-flath.github.io/APL-Exploration/posts/knapsack2.html">Knapsack II</a>
     2022-08-06, Felix Flath
   </article>
 
-  <article class="Example Challenge">
+  <article class="Tutorial Numeric-Math">
     <a href="https://isaac-flath.github.io/APL-Exploration/posts/knapsack.html">Knapsack</a>
     2022-08-06, Felix Flath
   </article>
   
-  <article class="Design">
+  <article class="Opinion Language-Design Idioms-Techniques">
     <a href="https://www.toolofthought.com/posts/on-control-structures">On Control Structures</a>
     2022-08-01, Paul Mansour
   </article>
 
-  <article class="Design">
+  <article class="Language-Design Opinion Interpreter-Internals">
     <a href="https://blog.dhsdevelopments.com/control-structures-in-kap">Control structures in KAP</a>
     2022-07-23, Elias Mårtenson
   </article>
 
-  <article class="Challenge">
+  <article class="Data-Query Puzzle-Solving">
     <a href="https://www.toolofthought.com/posts/leetcode-601">LeetCode 601: Human Traffic of Stadium</a>
     2022-07-09, Paul Mansour
   </article>
 
-  <article class="Pointfree">
+  <article class="Idioms-Techniques Data-Query">
     <a href="https://www.toolofthought.com/posts/trains">Trains</a>
     2022-07-08, Paul Mansour
   </article>
 
-  <article class="Challenge">
+  <article class="Data-Query Puzzle-Solving Numeric-Math">
     <a href="https://www.toolofthought.com/posts/leetcode-569">LeetCode 569: Median Employee Salary</a>
     2022-07-07, Paul Mansour
   </article>
 
-  <article class="Challenge">
+  <article class="Data-Query Puzzle-Solving">
     <a href="https://www.toolofthought.com/posts/leetcode-571">LeetCode 571: Find Median Given Frequency of Numbers</a>
     2022-07-06, Paul Mansour
   </article>
 
-  <article class="Challenge">
+  <article class="Data-Query Puzzle-Solving">
     <a href="https://www.toolofthought.com/posts/leetcode-262-trips-and-users">LeetCode 262: Trips and Users</a>
     2022-06-26, Paul Mansour
   </article>
 
-  <article class="Challenge">
+  <article class="Data-Query Puzzle-Solving Language-Design">
     <a href="https://www.toolofthought.com/posts/leetcode-185">LeetCode 185: Department Top Three Salaries</a>
     2022-06-25, Paul Mansour
   </article>
@@ -855,107 +855,107 @@
     2022-06-16, Adám Brudzewsky
   </article>
 
-  <article class="Example">
+  <article class="Opinion">
     <a href="https://github.com/justin2004/weblog/blob/master/using_apl/README.md">How it Feels to Use APL</a>
     2022-06-15, Justin Dowdy
   </article>
 
-  <article class="Idiom">
+  <article class="Language-Design Opinion Data-Query">
     <a href="https://www.toolofthought.com/posts/operators-in-a-dsl">Operators in a DSL</a>
     2022-05-28, Paul Mansour
   </article>
 
-  <article class="Commentary">
+  <article class="Opinion">
     <a href="https://blog.dhsdevelopments.com/commentary-on-array-cast">Commentary on Array Cast</a>
     2022-05-18, Elias Mårtenson
   </article>
 
-  <article class="Anecdote">
+  <article class="Cross-Language">
     <a href="https://www.dyalog.com/blog/2022/05/maintaining-pynapl-part-1-the-beginning">Maintaining Py’n’APL Part 1: The Beginning</a>
     2022-05-09, Rodrigo Girão Serrão
   </article>
 
-  <article class="Example Challenge">
+  <article class="Puzzle-Solving Tutorial">
     <a href="https://mathspp.com/blog/solving-wordle-with-apl">Solving Wordle with APL</a>
     2022-03-28, Rodrigo Girão Serrão
   </article>
 
-  <article class="Commentary">
+  <article class="Opinion Cross-Language">
     <a href="https://mathspp.com/blog/why-apl-is-a-language-worth-knowing">Why APL is a language worth knowing</a>
     2022-03-24, Rodrigo Girão Serrão
   </article>
 
-  <article class="Design">
+  <article class="Interpreter-Internals Language-Design">
     <a href="https://blog.dhsdevelopments.com/lazy-evaluation-helping-implementation-of-transform-by-mask-in-kap">Lazy evaluation helping implementation of transform by mask in KAP</a>
     2022-03-13, Elias Mårtenson
   </article>
   
-  <article class="Example">
+  <article class="Interpreter-Internals Language-Design">
     <a href="https://blog.dhsdevelopments.com/an-example-of-lazy-evaluation-in-kap">An example of lazy evaluation in KAP</a>
     2022-03-12, Elias Mårtenson
   </article>
   
-  <article class="Design">
+  <article class="Language-Design Opinion">
     <a href="https://outerproduct.net/2022-03-07_death-to-%E2%97%8B.html">Fixing APL’s Trigonometric Notation</a>
     2022-03-07, Moonchild
   </article>
 
-  <article class="Design">
+  <article class="Language-Design Opinion">
     <a href="https://www.toolofthought.com/posts/session-configuration">Session Configuration</a>
     2022-03-06, Paul Mansour
   </article>
 
-  <article class="Design">
+  <article class="Language-Design">
     <a href="https://www.toolofthought.com/posts/a-new-workspace-file-format">A New Workspace File Format</a>
     2022-02-26, Paul Mansour
   </article>
 
-  <article class="Mathematics">
+  <article class="Tutorial Numeric-Math">
     <a href="https://mathspp.com/blog/til/034">TIL #034 – multi-channel transposed convolution</a>
     2022-02-23, Rodrigo Girão Serrão
   </article>
 
-  <article class="Mathematics">
+  <article class="Tutorial Numeric-Math">
     <a href="https://mathspp.com/blog/til/033">TIL #033 – transposed convolution</a>
     2022-02-22, Rodrigo Girão Serrão
   </article>
 
-  <article class="Example Anecdote">
+  <article class="Idioms-Techniques Opinion">
     <a href="https://github.com/justin2004/weblog/blob/master/a_random_permutation/README.md">A Random Permutation</a>
     2022-02-17, Justin Dowdy
   </article>
 
-  <article class="Commentary">
+  <article class="Opinion">
     <a href="https://www.toolofthought.com/posts/aaronhsuquote">Aaron Hsu at Function Conf 2022</a>
     2022-01-27, Paul Mansour
   </article>
 
-  <article class="Example Idiom">
+  <article class="Tutorial Data-Query">
     <a href="https://www.toolofthought.com/posts/vfi-with-csv">⎕VFI with ⎕CSV</a>
     2022-01-25, Paul Mansour
   </article>
   
-  <article class="Mathematics">
+  <article class="Numeric-Math Tutorial">
     <a href="https://mathspp.com/blog/til/021">TIL #021 – Spouge's formula</a>
     2022-01-10, Rodrigo Girão Serrã
   </article>
 
-  <article class="Mathematics">
+  <article class="Numeric-Math Tutorial">
     <a href="https://palaiologos.rocks/posts/linalg-apl">Implementing the Faddeev-LeVerrier algorithm in APL</a>
     2022-01-10, Kamila Szewczyk
   </article>
   
-  <article class="Mathematics">
+  <article class="Numeric-Math Tutorial">
     <a href="https://palaiologos.rocks/posts/poly-root-apl">Finding roots of a polynomial - numerical methods in APL </a>
     2022-01-09, Kamila Szewczyk
   </article>
 
-  <article class="Mathematics">
+  <article class="Numeric-Math Tutorial">
     <a href="https://palaiologos.rocks/posts/taylor-apl">Implementing Taylor Series in APL</a>
     2022-01-06, Kamila Szewczyk
   </article>
 
-  <article class="Example">
+  <article class="Web-GUI Tutorial">
     <a href="https://optima-systems.co.uk/creating-a-graphical-user-interface-gui-in-dyalog-apl-part-1">Creating a Graphical User Interface (GUI) in Dyalog APL (Part 1)</a>
     2021-05-28, Sam Gutsell
   </article>

--- a/rss.xml
+++ b/rss.xml
@@ -10,8 +10,9 @@
       <pubDate>Wed, 26 Aug 2026 15:00:00 GMT</pubDate>
       <description>Andrea Piseri</description>
       <guid>https://ap29600.github.io/boolean_scans.html</guid>
-      <category>Implementation</category>
-      <category>Mathematics</category>
+      <category>Idioms-Techniques</category>
+      <category>Interpreter-Internals</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://loriculus.org/blog/chess-moves-apl/</link>
@@ -19,7 +20,8 @@
       <pubDate>Sun, 16 Aug 2026 15:00:00 GMT</pubDate>
       <description>Rohan Prinja</description>
       <guid>https://loriculus.org/blog/chess-moves-apl/</guid>
-      <category>Example</category>
+      <category>Puzzle-Solving</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://loriculus.org/blog/validate-sudoku-apl/</link>
@@ -27,8 +29,8 @@
       <pubDate>Wed, 12 Aug 2026 15:00:00 GMT</pubDate>
       <description>Rohan Prinja</description>
       <guid>https://loriculus.org/blog/validate-sudoku-apl/</guid>
-      <category>Example</category>
-      <category>Challenge</category>
+      <category>Tutorial</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://loriculus.org/blog/maximum-nesting-depth/</link>
@@ -36,7 +38,9 @@
       <pubDate>Sat, 01 Aug 2026 15:00:00 GMT</pubDate>
       <description>Rohan Prinja</description>
       <guid>https://loriculus.org/blog/maximum-nesting-depth/</guid>
-      <category>Example</category>
+      <category>Puzzle-Solving</category>
+      <category>Tutorial</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://butwhyisthat.substack.com/p/ecfp</link>
@@ -44,8 +48,9 @@
       <pubDate>Wed, 22 Jul 2026 15:00:00 GMT</pubDate>
       <description>Manas Mahale</description>
       <guid>https://butwhyisthat.substack.com/p/ecfp</guid>
-      <category>Design</category>
-      <category>Mathematics</category>
+      <category>Tutorial</category>
+      <category>Numeric-Math</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://loriculus.org/blog/run-length-encoding-apl/</link>
@@ -53,8 +58,9 @@
       <pubDate>Mon, 20 Jul 2026 15:00:00 GMT</pubDate>
       <description>Rohan Prinja</description>
       <guid>https://loriculus.org/blog/run-length-encoding-apl/</guid>
-      <category>Example</category>
-      <category>Idiom</category>
+      <category>Tutorial</category>
+      <category>Idioms-Techniques</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://loriculus.org/blog/mask-partition-apl/</link>
@@ -62,8 +68,8 @@
       <pubDate>Sun, 19 Jul 2026 15:00:00 GMT</pubDate>
       <description>Rohan Prinja</description>
       <guid>https://loriculus.org/blog/mask-partition-apl/</guid>
-      <category>Example</category>
-      <category>Idiom</category>
+      <category>Tutorial</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://loriculus.org/blog/apl-problems/</link>
@@ -71,8 +77,8 @@
       <pubDate>Tue, 14 Jul 2026 15:00:00 GMT</pubDate>
       <description>Rohan Prinja</description>
       <guid>https://loriculus.org/blog/apl-problems/</guid>
-      <category>Challenge</category>
-      <category>Example</category>
+      <category>Puzzle-Solving</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://loriculus.org/blog/useful-apl-idioms/</link>
@@ -80,7 +86,7 @@
       <pubDate>Mon, 13 Jul 2026 15:00:00 GMT</pubDate>
       <description>Rohan Prinja</description>
       <guid>https://loriculus.org/blog/useful-apl-idioms/</guid>
-      <category>Idiom</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/csv-files-reconsidered</link>
@@ -88,8 +94,9 @@
       <pubDate>Thu, 21 May 2026 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/csv-files-reconsidered</guid>
-      <category>Design</category>
-      <category>Implementation</category>
+      <category>Opinion</category>
+      <category>Data-Query</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/apl-makes-us-smile</link>
@@ -97,8 +104,8 @@
       <pubDate>Thu, 21 May 2026 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/apl-makes-us-smile</guid>
-      <category>Design</category>
-      <category>Example</category>
+      <category>Opinion</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://maxcan-code.github.io/blog/2026/05/19/power-user-apl.html</link>
@@ -106,8 +113,8 @@
       <pubDate>Tue, 19 May 2026 15:00:00 GMT</pubDate>
       <description>Max Sun</description>
       <guid>https://maxcan-code.github.io/blog/2026/05/19/power-user-apl.html</guid>
-      <category>Example</category>
-      <category>Design</category>
+      <category>Tutorial</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://homewithinnowhere.com/posts/2026-05-10-one-line.html</link>
@@ -115,8 +122,8 @@
       <pubDate>Sun, 10 May 2026 15:00:00 GMT</pubDate>
       <description>Kyle Croarkin</description>
       <guid>https://homewithinnowhere.com/posts/2026-05-10-one-line.html</guid>
-      <category>Design</category>
-      <category>Mathematics</category>
+      <category>Opinion</category>
+      <category>Web-GUI</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/a-query-in-r</link>
@@ -124,8 +131,8 @@
       <pubDate>Fri, 08 May 2026 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/a-query-in-r</guid>
-      <category>Commentary</category>
-      <category>Language-comparison</category>
+      <category>Cross-Language</category>
+      <category>Data-Query</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/a-little-comparison-between-r-and-kap</link>
@@ -133,8 +140,8 @@
       <pubDate>Sat, 02 May 2026 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/a-little-comparison-between-r-and-kap</guid>
-      <category>Language-comparison</category>
-      <category>Example</category>
+      <category>Cross-Language</category>
+      <category>Data-Query</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/kap-performance</link>
@@ -142,7 +149,7 @@
       <pubDate>Mon, 13 Apr 2026 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/kap-performance</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/new-gui-for-kap</link>
@@ -150,7 +157,8 @@
       <pubDate>Thu, 02 Apr 2026 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/new-gui-for-kap</guid>
-      <category>Implementation</category>
+      <category>Announcement</category>
+      <category>Web-GUI</category>
     </item>
     <item>
       <link>https://homewithinnowhere.com/blog/voxel_game/</link>
@@ -158,8 +166,8 @@
       <pubDate>Fri, 06 Mar 2026 15:00:00 GMT</pubDate>
       <description>Kyle Croarkin</description>
       <guid>https://homewithinnowhere.com/blog/voxel_game/</guid>
-      <category>Example</category>
-      <category>Design</category>
+      <category>Tutorial</category>
+      <category>Web-GUI</category>
     </item>
     <item>
       <link>https://blog.wilsonb.com/posts/2026-02-27-easy-random-trees.html</link>
@@ -167,7 +175,8 @@
       <pubDate>Fri, 27 Feb 2026 15:00:00 GMT</pubDate>
       <description>Brandon Wilson</description>
       <guid>https://blog.wilsonb.com/posts/2026-02-27-easy-random-trees.html</guid>
-      <category>Mathematics</category>
+      <category>Numeric-Math</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://blog.veitheller.de/A_quick_apology_to_Dyalog_APL.html</link>
@@ -175,7 +184,8 @@
       <pubDate>Sat, 31 Jan 2026 15:00:00 GMT</pubDate>
       <description>Veit Heller</description>
       <guid>https://blog.veitheller.de/A_quick_apology_to_Dyalog_APL.html</guid>
-      <category>Commentary</category>
+      <category>Opinion</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://blog.veitheller.de/Simple_Sudoku_Solvers_SII,_EI:_Dyalog_APL.html</link>
@@ -183,8 +193,8 @@
       <pubDate>Tue, 20 Jan 2026 15:00:00 GMT</pubDate>
       <description>Veit Heller</description>
       <guid>https://blog.veitheller.de/Simple_Sudoku_Solvers_SII,_EI:_Dyalog_APL.html</guid>
-      <category>Example</category>
-      <category>Language-comparison</category>
+      <category>Tutorial</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/variation-on-iota</link>
@@ -192,8 +202,7 @@
       <pubDate>Wed, 12 Nov 2025 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/variation-on-iota</guid>
-      <category>Example</category>
-      <category>Pointfree</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://www.sacrideo.us/multi-dimensional-weighted-random-roll-choice-dice-selection/</link>
@@ -201,8 +210,8 @@
       <pubDate>Sat, 30 Aug 2025 15:00:00 GMT</pubDate>
       <description>Aaron Hsu</description>
       <guid>https://www.sacrideo.us/multi-dimensional-weighted-random-roll-choice-dice-selection/</guid>
-      <category>Example</category>
-      <category>Challenge</category>
+      <category>Idioms-Techniques</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/on-arguments</link>
@@ -210,8 +219,8 @@
       <pubDate>Fri, 15 Aug 2025 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/on-arguments</guid>
-      <category>Example</category>
-      <category>Commentary</category>
+      <category>Opinion</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/menus-revisited</link>
@@ -219,7 +228,8 @@
       <pubDate>Sat, 09 Aug 2025 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/menus-revisited</guid>
-      <category>Example</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/input-components</link>
@@ -227,8 +237,8 @@
       <pubDate>Wed, 06 Aug 2025 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/input-components</guid>
-      <category>Example</category>
-      <category>Commentary</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/whats-on-the-menu</link>
@@ -236,7 +246,9 @@
       <pubDate>Sat, 21 Jun 2025 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/whats-on-the-menu</guid>
-      <category>Example</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://pitr.ca/2025-06-14-queens</link>
@@ -244,7 +256,8 @@
       <pubDate>Sat, 14 Jun 2025 15:00:00 GMT</pubDate>
       <description>Peter Vernigorov</description>
       <guid>https://pitr.ca/2025-06-14-queens</guid>
-      <category>Challenge</category>
+      <category>Puzzle-Solving</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/grok-as-apl-interpreter</link>
@@ -252,7 +265,8 @@
       <pubDate>Wed, 04 Jun 2025 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/grok-as-apl-interpreter</guid>
-      <category>Commentary</category>
+      <category>Opinion</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_15_extra_arguments</link>
@@ -260,8 +274,9 @@
       <pubDate>Thu, 13 Mar 2025 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_15_extra_arguments</guid>
-      <category>Implementation</category>
-      <category>Design</category>
+      <category>Announcement</category>
+      <category>Interpreter-Internals</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/finding-words-using-kap</link>
@@ -269,8 +284,8 @@
       <pubDate>Tue, 25 Feb 2025 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/finding-words-using-kap</guid>
-      <category>Example</category>
-      <category>Commentary</category>
+      <category>Tutorial</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/axis-labels-in-kap</link>
@@ -278,7 +293,9 @@
       <pubDate>Mon, 17 Feb 2025 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/axis-labels-in-kap</guid>
-      <category>Challenge</category>
+      <category>Tutorial</category>
+      <category>Data-Query</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/html-tables-revisited</link>
@@ -286,8 +303,8 @@
       <pubDate>Sun, 16 Feb 2025 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/html-tables-revisited</guid>
-      <category>Example</category>
-      <category>Commentary</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/rethinking-vset-and-vget</link>
@@ -295,8 +312,8 @@
       <pubDate>Wed, 05 Feb 2025 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/rethinking-vset-and-vget</guid>
-      <category>Design</category>
-      <category>Commentary</category>
+      <category>Language-Design</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/version-20-goodies</link>
@@ -304,7 +321,8 @@
       <pubDate>Fri, 31 Jan 2025 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/version-20-goodies</guid>
-      <category>Language-comparison</category>
+      <category>Tutorial</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/new-tricks-for-old-dogs</link>
@@ -312,7 +330,8 @@
       <pubDate>Wed, 29 Jan 2025 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/new-tricks-for-old-dogs</guid>
-      <category>Language-comparison</category>
+      <category>Opinion</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/advent-of-code-2024-part-2</link>
@@ -320,7 +339,8 @@
       <pubDate>Sun, 12 Jan 2025 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/advent-of-code-2024-part-2</guid>
-      <category>Challenge</category>
+      <category>Puzzle-Solving</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/html-templates</link>
@@ -328,7 +348,8 @@
       <pubDate>Tue, 07 Jan 2025 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/html-templates</guid>
-      <category>Example</category>
+      <category>Opinion</category>
+      <category>Web-GUI</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/advent-of-code-2024</link>
@@ -336,7 +357,8 @@
       <pubDate>Sat, 28 Dec 2024 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/advent-of-code-2024</guid>
-      <category>Challenge</category>
+      <category>Puzzle-Solving</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://blog.wilsonb.com/posts/2024-12-14-aoc-14.html</link>
@@ -344,8 +366,8 @@
       <pubDate>Sat, 14 Dec 2024 15:00:00 GMT</pubDate>
       <description>Brandon Wilson</description>
       <guid>https://blog.wilsonb.com/posts/2024-12-14-aoc-14.html</guid>
-      <category>Mathematics</category>
-      <category>Challenge</category>
+      <category>Puzzle-Solving</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://blog.wilsonb.com/posts/2024-12-14-aoc-13.html</link>
@@ -353,8 +375,8 @@
       <pubDate>Sat, 14 Dec 2024 15:00:00 GMT</pubDate>
       <description>Brandon Wilson</description>
       <guid>https://blog.wilsonb.com/posts/2024-12-14-aoc-13.html</guid>
-      <category>Mathematics</category>
-      <category>Challenge</category>
+      <category>Puzzle-Solving</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_14_dictionaries</link>
@@ -362,7 +384,8 @@
       <pubDate>Sat, 30 Nov 2024 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_14_dictionaries</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://medium.com/@solarbreeze69/presenting-queztcoapl-2cdc1b9d234b</link>
@@ -370,9 +393,8 @@
       <pubDate>Thu, 28 Nov 2024 15:00:00 GMT</pubDate>
       <description>solarbreeze</description>
       <guid>https://medium.com/@solarbreeze69/presenting-queztcoapl-2cdc1b9d234b</guid>
-      <category>Vintage</category>
       <category>Announcement</category>
-      <category>Example</category>
+      <category>Interpreter-Internals</category>
     </item>
     <item>
       <link>https://jcarroll.com.au/2024/11/28/these-languages-are-accumulating/</link>
@@ -380,8 +402,8 @@
       <pubDate>Thu, 28 Nov 2024 15:00:00 GMT</pubDate>
       <description>Jonathan Carroll</description>
       <guid>https://jcarroll.com.au/2024/11/28/these-languages-are-accumulating/</guid>
-      <category>Language-comparison</category>
-      <category>Idiom</category>
+      <category>Cross-Language</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/find-and-replace-with-interval-index</link>
@@ -389,8 +411,8 @@
       <pubDate>Thu, 07 Nov 2024 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/find-and-replace-with-interval-index</guid>
-      <category>Education</category>
-      <category>Example</category>
+      <category>Tutorial</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/an-imperative-introduction-to-array-programming</link>
@@ -398,9 +420,8 @@
       <pubDate>Wed, 30 Oct 2024 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/an-imperative-introduction-to-array-programming</guid>
-      <category>Design</category>
-      <category>Language-comparison</category>
-      <category>Education</category>
+      <category>Tutorial</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_13_biggest_mistake_biggest_change</link>
@@ -408,7 +429,8 @@
       <pubDate>Sun, 27 Oct 2024 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_13_biggest_mistake_biggest_change</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://jcarroll.com.au/2024/10/26/polyglot-maxxie-and-minnie/</link>
@@ -416,8 +438,8 @@
       <pubDate>Sat, 26 Oct 2024 15:00:00 GMT</pubDate>
       <description>Jonathan Carroll</description>
       <guid>https://jcarroll.com.au/2024/10/26/polyglot-maxxie-and-minnie/</guid>
-      <category>Language-comparison</category>
-      <category>Challenge</category>
+      <category>Cross-Language</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_12_at_depth_ordering</link>
@@ -425,7 +447,8 @@
       <pubDate>Wed, 02 Oct 2024 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_12_at_depth_ordering</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://blog.wilsonb.com/posts/2024-09-27-brainfuck.html</link>
@@ -433,8 +456,8 @@
       <pubDate>Fri, 27 Sep 2024 15:00:00 GMT</pubDate>
       <description>Brandon Wilson</description>
       <guid>https://blog.wilsonb.com/posts/2024-09-27-brainfuck.html</guid>
-      <category>Example</category>
-      <category>Design</category>
+      <category>Tutorial</category>
+      <category>Interpreter-Internals</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_11_bases_searching</link>
@@ -442,7 +465,8 @@
       <pubDate>Fri, 13 Sep 2024 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_11_bases_searching</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_10_wraps_structs_stdlib</link>
@@ -450,7 +474,8 @@
       <pubDate>Tue, 03 Sep 2024 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_10_wraps_structs_stdlib</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_9_more_tacit</link>
@@ -458,7 +483,9 @@
       <pubDate>Sat, 10 Aug 2024 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_9_more_tacit</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Idioms-Techniques</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_8_rank_web</link>
@@ -466,7 +493,8 @@
       <pubDate>Sat, 03 Aug 2024 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_8_rank_web</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Web-GUI</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/rumba-threading-model</link>
@@ -474,7 +502,8 @@
       <pubDate>Sun, 28 Jul 2024 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/rumba-threading-model</guid>
-      <category>Implementation</category>
+      <category>Language-Design</category>
+      <category>Interpreter-Internals</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/revisiting-rumba</link>
@@ -482,7 +511,8 @@
       <pubDate>Wed, 17 Jul 2024 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/revisiting-rumba</guid>
-      <category>Implementation</category>
+      <category>Announcement</category>
+      <category>Interpreter-Internals</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_7_quads_key_index</link>
@@ -490,7 +520,8 @@
       <pubDate>Thu, 30 May 2024 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_7_quads_key_index</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_6_tests_docs_each</link>
@@ -498,7 +529,7 @@
       <pubDate>Tue, 21 May 2024 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_6_tests_docs_each</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/a-high-performance-data-grid-in-html</link>
@@ -506,7 +537,8 @@
       <pubDate>Mon, 20 May 2024 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/a-high-performance-data-grid-in-html</guid>
-      <category>Example</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/modal-dialog-boxes-progressbar-more</link>
@@ -514,7 +546,8 @@
       <pubDate>Sat, 18 May 2024 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/modal-dialog-boxes-progressbar-more</guid>
-      <category>Example</category>
+      <category>Tutorial</category>
+      <category>Web-GUI</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/modal-dialog-boxes-progressbar</link>
@@ -522,7 +555,8 @@
       <pubDate>Tue, 14 May 2024 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/modal-dialog-boxes-progressbar</guid>
-      <category>Example</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/uncle-bob-and-the-primeagen</link>
@@ -530,8 +564,7 @@
       <pubDate>Tue, 07 May 2024 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/uncle-bob-and-the-primeagen</guid>
-      <category>Commentary</category>
-      <category>Testing</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/modal-dialog-boxes-prompt</link>
@@ -539,7 +572,8 @@
       <pubDate>Mon, 06 May 2024 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/modal-dialog-boxes-prompt</guid>
-      <category>Example</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/modal-dialog-boxes-confirm</link>
@@ -547,7 +581,8 @@
       <pubDate>Tue, 30 Apr 2024 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/modal-dialog-boxes-confirm</guid>
-      <category>Example</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/modal-dialog-boxes-1</link>
@@ -555,7 +590,8 @@
       <pubDate>Mon, 29 Apr 2024 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/modal-dialog-boxes-1</guid>
-      <category>Example</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://bl0v3.com/Blog/raymarching-in-dyalog-apl/</link>
@@ -563,7 +599,8 @@
       <pubDate>Sun, 28 Apr 2024 15:00:00 GMT</pubDate>
       <description>bl0v3</description>
       <guid>https://bl0v3.com/Blog/raymarching-in-dyalog-apl/</guid>
-      <category>Mathematics</category>
+      <category>Tutorial</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/abacus-threading-model</link>
@@ -571,7 +608,8 @@
       <pubDate>Sun, 28 Apr 2024 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/abacus-threading-model</guid>
-      <category>Example</category>
+      <category>Web-GUI</category>
+      <category>Interpreter-Internals</category>
     </item>
     <item>
       <link>https://grahamenos.com/apl-min-plus.html</link>
@@ -579,8 +617,7 @@
       <pubDate>Thu, 04 Apr 2024 15:00:00 GMT</pubDate>
       <description>Graham Enos</description>
       <guid>https://grahamenos.com/apl-min-plus.html</guid>
-      <category>Example</category>
-      <category>Mathematics</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://www.dyalog.com/blog/2024/03/the-apl-quest-series/</link>
@@ -589,8 +626,7 @@
       <description>Adám Brudzewsky</description>
       <guid>https://www.dyalog.com/blog/2024/03/the-apl-quest-series/</guid>
       <category>Announcement</category>
-      <category>Anecdote</category>
-      <category>Commentary</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_5_array_notation_reductions</link>
@@ -598,7 +634,8 @@
       <pubDate>Thu, 14 Mar 2024 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_5_array_notation_reductions</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_4_parsing</link>
@@ -606,7 +643,7 @@
       <pubDate>Mon, 11 Mar 2024 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_4_parsing</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/array-languages-vs</link>
@@ -614,9 +651,8 @@
       <pubDate>Sun, 25 Feb 2024 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/array-languages-vs</guid>
-      <category>Design</category>
-      <category>Implementation</category>
-      <category>Language-comparison</category>
+      <category>Opinion</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://palaiologos.rocks/posts/polygon-triangulation/</link>
@@ -624,7 +660,8 @@
       <pubDate>Fri, 23 Feb 2024 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
       <guid>https://palaiologos.rocks/posts/polygon-triangulation/</guid>
-      <category>Mathematics</category>
+      <category>Tutorial</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://scharenbroch.dev/projects/apl-interpreter/</link>
@@ -632,7 +669,8 @@
       <pubDate>Thu, 11 Jan 2024 15:00:00 GMT</pubDate>
       <description>Lucas Scharenbroch</description>
       <guid>https://scharenbroch.dev/projects/apl-interpreter/</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://github.com/justin2004/weblog/blob/master/design_implications/README.md</link>
@@ -640,9 +678,9 @@
       <pubDate>Tue, 09 Jan 2024 15:00:00 GMT</pubDate>
       <description>Justin Dowdy</description>
       <guid>https://github.com/justin2004/weblog/blob/master/design_implications/README.md</guid>
-      <category>Language-comparison</category>
-      <category>Example</category>
-      <category>Commentary</category>
+      <category>Opinion</category>
+      <category>Language-Design</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://medium.com/@solarbreeze69/exploring-the-apl-one-liner-solutions-to-logikers-christmas-challenge-2023-on-the-commodore-64-b027e6ee486b</link>
@@ -651,9 +689,8 @@
       <pubDate>Fri, 05 Jan 2024 15:00:00 GMT</pubDate>
       <description>solarbreeze</description>
       <guid>https://medium.com/@solarbreeze69/exploring-the-apl-one-liner-solutions-to-logikers-christmas-challenge-2023-on-the-commodore-64-b027e6ee486b</guid>
-      <category>Vintage</category>
-      <category>Challenge</category>
-      <category>Language-comparison</category>
+      <category>Puzzle-Solving</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://medium.com/@solarbreeze69/two-apl-solutions-to-logikers-vintage-computing-christmas-challenge-2023-014feacc8a8f</link>
@@ -662,8 +699,7 @@
       <pubDate>Wed, 27 Dec 2023 15:00:00 GMT</pubDate>
       <description>solarbreeze</description>
       <guid>https://medium.com/@solarbreeze69/two-apl-solutions-to-logikers-vintage-computing-christmas-challenge-2023-014feacc8a8f</guid>
-      <category>Vintage</category>
-      <category>Challenge</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/making-sharpplot-charts-interactive</link>
@@ -671,8 +707,8 @@
       <pubDate>Thu, 21 Dec 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/making-sharpplot-charts-interactive</guid>
-      <category>Design</category>
-      <category>Implementation</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://xpqz.github.io/Advent-of-Code-day-8/</link>
@@ -680,7 +716,9 @@
       <pubDate>Mon, 11 Dec 2023 15:00:00 GMT</pubDate>
       <description>Stefan Kruger</description>
       <guid>https://xpqz.github.io/Advent-of-Code-day-8/</guid>
-      <category>Challenge</category>
+      <category>Puzzle-Solving</category>
+      <category>Tutorial</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://jcarroll.com.au/2023/12/10/advent-of-array-elegance/</link>
@@ -688,7 +726,8 @@
       <pubDate>Sun, 10 Dec 2023 15:00:00 GMT</pubDate>
       <description>Jonathan Carroll</description>
       <guid>https://jcarroll.com.au/2023/12/10/advent-of-array-elegance/</guid>
-      <category>Language-comparison</category>
+      <category>Puzzle-Solving</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/on-categorical-data</link>
@@ -696,7 +735,9 @@
       <pubDate>Wed, 06 Dec 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/on-categorical-data</guid>
-      <category>Mathematics</category>
+      <category>Tutorial</category>
+      <category>Data-Query</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://xpqz.github.io/Advent-of-Code-Day-3/</link>
@@ -704,7 +745,9 @@
       <pubDate>Tue, 05 Dec 2023 15:00:00 GMT</pubDate>
       <description>Stefan Kruger</description>
       <guid>https://xpqz.github.io/Advent-of-Code-Day-3/</guid>
-      <category>Challenge</category>
+      <category>Puzzle-Solving</category>
+      <category>Tutorial</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://xpqz.github.io/AoC-day1/</link>
@@ -712,7 +755,8 @@
       <pubDate>Fri, 01 Dec 2023 15:00:00 GMT</pubDate>
       <description>Stefan Kruger</description>
       <guid>https://xpqz.github.io/AoC-day1/</guid>
-      <category>Challenge</category>
+      <category>Puzzle-Solving</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://scharenbroch.dev/blog/apl-tutorial/</link>
@@ -720,7 +764,8 @@
       <pubDate>Mon, 27 Nov 2023 15:00:00 GMT</pubDate>
       <description>Lucas Scharenbroch</description>
       <guid>https://scharenbroch.dev/blog/apl-tutorial/</guid>
-      <category>Education</category>
+      <category>Tutorial</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_3_more_primitives</link>
@@ -728,7 +773,8 @@
       <pubDate>Tue, 21 Nov 2023 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_3_more_primitives</guid>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/high-rank-arrays</link>
@@ -736,8 +782,9 @@
       <pubDate>Wed, 15 Nov 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/high-rank-arrays</guid>
-      <category>Commentary</category>
-      <category>Design</category>
+      <category>Opinion</category>
+      <category>Data-Query</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/n-tuples-and-the-introduction-of-null-values-in-kap</link>
@@ -745,7 +792,8 @@
       <pubDate>Mon, 06 Nov 2023 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/n-tuples-and-the-introduction-of-null-values-in-kap</guid>
-      <category>Design</category>
+      <category>Language-Design</category>
+      <category>Interpreter-Internals</category>
     </item>
     <item>
       <link>https://jcarroll.com.au/2023/10/09/hooray-array/</link>
@@ -753,7 +801,8 @@
       <pubDate>Mon, 09 Oct 2023 15:00:00 GMT</pubDate>
       <description>Jonathan Carroll</description>
       <guid>https://jcarroll.com.au/2023/10/09/hooray-array/</guid>
-      <category>Language-comparison</category>
+      <category>Cross-Language</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://palaiologos.rocks/posts/dan-baronets-microwave/</link>
@@ -761,8 +810,8 @@
       <pubDate>Wed, 04 Oct 2023 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
       <guid>https://palaiologos.rocks/posts/dan-baronets-microwave/</guid>
-      <category>Mathematics</category>
-      <category>Anecdote</category>
+      <category>Puzzle-Solving</category>
+      <category>Announcement</category>
     </item>
     <item>
       <link>https://medium.com/@solarbreeze69/draculark-a-mudlarking-vampire-hunting-game-bbf40361bf1a</link>
@@ -770,8 +819,7 @@
       <pubDate>Fri, 29 Sep 2023 15:00:00 GMT</pubDate>
       <description>solarbreeze</description>
       <guid>https://medium.com/@solarbreeze69/draculark-a-mudlarking-vampire-hunting-game-bbf40361bf1a</guid>
-      <category>Vintage</category>
-      <category>Implementation</category>
+      <category>Announcement</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/charting-and-tidy-data</link>
@@ -779,7 +827,8 @@
       <pubDate>Thu, 28 Sep 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/charting-and-tidy-data</guid>
-      <category>Commentary</category>
+      <category>Web-GUI</category>
+      <category>Data-Query</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/project-playfair</link>
@@ -787,7 +836,8 @@
       <pubDate>Wed, 27 Sep 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/project-playfair</guid>
-      <category>Design</category>
+      <category>Web-GUI</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/ordered-namespaces</link>
@@ -795,7 +845,8 @@
       <pubDate>Tue, 26 Sep 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/ordered-namespaces</guid>
-      <category>Example</category>
+      <category>Tutorial</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_2_functions_operators</link>
@@ -803,8 +854,8 @@
       <pubDate>Sat, 23 Sep 2023 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_2_functions_operators</guid>
-      <category>Design</category>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/towards-a-chart-wizard</link>
@@ -812,7 +863,8 @@
       <pubDate>Wed, 20 Sep 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/towards-a-chart-wizard</guid>
-      <category>Design</category>
+      <category>Web-GUI</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/float_indexing</link>
@@ -820,8 +872,9 @@
       <pubDate>Fri, 01 Sep 2023 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/float_indexing</guid>
-      <category>Design</category>
-      <category>Humour</category>
+      <category>Language-Design</category>
+      <category>Opinion</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://jcarroll.com.au/2023/08/29/now-you-re-thinking-with-arrays/</link>
@@ -829,7 +882,8 @@
       <pubDate>Tue, 29 Aug 2023 15:00:00 GMT</pubDate>
       <description>Jonathan Carroll</description>
       <guid>https://jcarroll.com.au/2023/08/29/now-you-re-thinking-with-arrays/</guid>
-      <category>Language-comparison</category>
+      <category>Cross-Language</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://blog.wilsonb.com/posts/2023-08-29-mundane-exotic-number-system.html</link>
@@ -837,7 +891,8 @@
       <pubDate>Tue, 29 Aug 2023 15:00:00 GMT</pubDate>
       <description>Brandon Wilson</description>
       <guid>https://blog.wilsonb.com/posts/2023-08-29-mundane-exotic-number-system.html</guid>
-      <category>Mathematics</category>
+      <category>Numeric-Math</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/testing-guis-wrestling-with-events</link>
@@ -845,7 +900,8 @@
       <pubDate>Fri, 18 Aug 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/testing-guis-wrestling-with-events</guid>
-      <category>Testing</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://mathspp.com/blog/what-learning-apl-taught-me-about-python</link>
@@ -853,9 +909,9 @@
       <pubDate>Tue, 15 Aug 2023 15:00:00 GMT</pubDate>
       <description>Rodrigo Girão Serrão</description>
       <guid>https://mathspp.com/blog/what-learning-apl-taught-me-about-python</guid>
-      <category>Example</category>
-      <category>Anecdote</category>
-      <category>Language-comparison</category>
+      <category>Cross-Language</category>
+      <category>Opinion</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/testing-guis</link>
@@ -863,7 +919,8 @@
       <pubDate>Mon, 14 Aug 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/testing-guis</guid>
-      <category>Testing</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://palaiologos.rocks/posts/avg/</link>
@@ -871,8 +928,8 @@
       <pubDate>Sun, 13 Aug 2023 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
       <guid>https://palaiologos.rocks/posts/avg/</guid>
-      <category>Mathematics</category>
-      <category>Challenge</category>
+      <category>Numeric-Math</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://palaiologos.rocks/posts/lc-apl/</link>
@@ -880,8 +937,8 @@
       <pubDate>Sun, 13 Aug 2023 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
       <guid>https://palaiologos.rocks/posts/lc-apl/</guid>
-      <category>Implementation</category>
-      <category>Mathematics</category>
+      <category>Interpreter-Internals</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://ap29600.github.io/apl_problemsolving_23.html</link>
@@ -889,8 +946,7 @@
       <pubDate>Fri, 11 Aug 2023 15:00:00 GMT</pubDate>
       <description>Andrea Piseri</description>
       <guid>https://ap29600.github.io/apl_problemsolving_23.html</guid>
-      <category>Commentary</category>
-      <category>Example</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/tinyapl_1_arrays</link>
@@ -898,8 +954,9 @@
       <pubDate>Sat, 05 Aug 2023 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/tinyapl_1_arrays</guid>
-      <category>Design</category>
-      <category>Implementation</category>
+      <category>Interpreter-Internals</category>
+      <category>Tutorial</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://blog.wilsonb.com/posts/2023-08-04-what-does-grade-grade-even-mean.html</link>
@@ -907,9 +964,8 @@
       <pubDate>Fri, 04 Aug 2023 15:00:00 GMT</pubDate>
       <description>Brandon Wilson</description>
       <guid>https://blog.wilsonb.com/posts/2023-08-04-what-does-grade-grade-even-mean.html</guid>
-      <category>Example</category>
-      <category>Commentary</category>
-      <category>Challenge</category>
+      <category>Idioms-Techniques</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://blog.rubenverg.com/suggestivity_and_idioms</link>
@@ -917,9 +973,8 @@
       <pubDate>Thu, 27 Jul 2023 15:00:00 GMT</pubDate>
       <description>Madeline Vergani</description>
       <guid>https://blog.rubenverg.com/suggestivity_and_idioms</guid>
-      <category>Example</category>
-      <category>Commentary</category>
-      <category>Idiom</category>
+      <category>Idioms-Techniques</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://blog.wilsonb.com/posts/2023-07-24-suggestivity-and-idioms.html</link>
@@ -927,9 +982,9 @@
       <pubDate>Mon, 24 Jul 2023 15:00:00 GMT</pubDate>
       <description>Brandon Wilson</description>
       <guid>https://blog.wilsonb.com/posts/2023-07-24-suggestivity-and-idioms.html</guid>
-      <category>Example</category>
-      <category>Commentary</category>
-      <category>Idiom</category>
+      <category>Idioms-Techniques</category>
+      <category>Language-Design</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://medium.com/@solarbreeze69/superpet-apl-trek-493689243f05</link>
@@ -937,7 +992,7 @@
       <pubDate>Tue, 18 Jul 2023 15:00:00 GMT</pubDate>
       <description>solarbreeze</description>
       <guid>https://medium.com/@solarbreeze69/superpet-apl-trek-493689243f05</guid>
-      <category>Vintage</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://jcarroll.com.au/2023/07/07/array-languages-r-vs-apl/</link>
@@ -945,7 +1000,8 @@
       <pubDate>Fri, 07 Jul 2023 15:00:00 GMT</pubDate>
       <description>Jonathan Carroll</description>
       <guid>https://jcarroll.com.au/2023/07/07/array-languages-r-vs-apl/</guid>
-      <category>Language-comparison</category>
+      <category>Cross-Language</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/boolean-techniques</link>
@@ -953,9 +1009,7 @@
       <pubDate>Sat, 13 May 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/boolean-techniques</guid>
-      <category>Example</category>
-      <category>Commentary</category>
-      <category>Idiom</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/dont-trap-when-you-can-verify</link>
@@ -963,7 +1017,7 @@
       <pubDate>Thu, 11 May 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/dont-trap-when-you-can-verify</guid>
-      <category>Design</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/excel-column-names</link>
@@ -971,8 +1025,8 @@
       <pubDate>Mon, 08 May 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/excel-column-names</guid>
-      <category>Challenge</category>
-      <category>Commentary</category>
+      <category>Tutorial</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://www.sacrideo.us/suggestivity-and-idioms-in-apl/</link>
@@ -980,8 +1034,8 @@
       <pubDate>Tue, 02 May 2023 15:00:00 GMT</pubDate>
       <description>Aaron Hsu</description>
       <guid>https://www.sacrideo.us/suggestivity-and-idioms-in-apl/</guid>
-      <category>Example</category>
-      <category>Idiom</category>
+      <category>Idioms-Techniques</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.sacrideo.us/flat-program-organization-an-email-response/</link>
@@ -989,7 +1043,7 @@
       <pubDate>Fri, 21 Apr 2023 15:00:00 GMT</pubDate>
       <description>Aaron Hsu</description>
       <guid>https://www.sacrideo.us/flat-program-organization-an-email-response/</guid>
-      <category>Commentary</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.dyalog.com/blog/2023/04/formal-proposal-for-apl-array-notation-seeking-feedback</link>
@@ -997,7 +1051,7 @@
       <pubDate>Fri, 21 Apr 2023 15:00:00 GMT</pubDate>
       <description>Morten Kromberg</description>
       <guid>https://www.dyalog.com/blog/2023/04/formal-proposal-for-apl-array-notation-seeking-feedback</guid>
-      <category>Design</category>
+      <category>Language-Design</category>
       <category>Announcement</category>
     </item>
     <item>
@@ -1006,7 +1060,8 @@
       <pubDate>Wed, 12 Apr 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/dom-via-json-performance</guid>
-      <category>Example</category>
+      <category>Web-GUI</category>
+      <category>Interpreter-Internals</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/the-dom-via-json</link>
@@ -1014,7 +1069,8 @@
       <pubDate>Tue, 11 Apr 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/the-dom-via-json</guid>
-      <category>Example</category>
+      <category>Tutorial</category>
+      <category>Web-GUI</category>
     </item>
     <item>
       <link>https://www.dyalog.com/blog/2023/04/11-april-2023-a-day-to-celebrate</link>
@@ -1030,8 +1086,8 @@
       <pubDate>Sat, 01 Apr 2023 15:00:00 GMT</pubDate>
       <description>Morten Kromberg</description>
       <guid>https://www.dyalog.com/blog/2023/04/extending-structural-functions-to-scalars</guid>
-      <category>Design</category>
       <category>Announcement</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://www.dyalog.com/blog/2023/03/apl-seeds-23-wednesday-22-march</link>
@@ -1047,7 +1103,9 @@
       <pubDate>Mon, 27 Mar 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/validating-dates</guid>
-      <category>Example</category>
+      <category>Numeric-Math</category>
+      <category>Data-Query</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/grade-up-of-grade-down</link>
@@ -1055,8 +1113,8 @@
       <pubDate>Tue, 21 Mar 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/grade-up-of-grade-down</guid>
-      <category>Example</category>
-      <category>Challenge</category>
+      <category>Idioms-Techniques</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://www.sacrideo.us/2023-apl-problem-solving-competition</link>
@@ -1065,7 +1123,7 @@
       <description>Aaron Hsu</description>
       <guid>https://www.sacrideo.us/2023-apl-problem-solving-competition</guid>
       <category>Announcement</category>
-      <category>Commentary</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/how-would-you-write-this</link>
@@ -1073,8 +1131,8 @@
       <pubDate>Sun, 05 Mar 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/how-would-you-write-this</guid>
-      <category>Design</category>
-      <category>Idiom</category>
+      <category>Opinion</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://razetime.github.io/blog/2023/03/02/apl-assumptions.html</link>
@@ -1082,7 +1140,7 @@
       <pubDate>Thu, 02 Mar 2023 15:00:00 GMT</pubDate>
       <description>Raghu Ranganathan</description>
       <guid>https://razetime.github.io/blog/2023/03/02/apl-assumptions.html</guid>
-      <category>Commentary</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/text2date</link>
@@ -1091,6 +1149,7 @@
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/text2date</guid>
       <category>Announcement</category>
+      <category>Data-Query</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/error-trapping</link>
@@ -1098,7 +1157,7 @@
       <pubDate>Mon, 20 Feb 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/error-trapping</guid>
-      <category>Example</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/provanto</link>
@@ -1106,7 +1165,7 @@
       <pubDate>Mon, 13 Feb 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/provanto</guid>
-      <category>Design</category>
+      <category>Announcement</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/returning-from-functions-in-kap</link>
@@ -1114,8 +1173,8 @@
       <pubDate>Sat, 04 Feb 2023 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/returning-from-functions-in-kap</guid>
-      <category>Design</category>
-      <category>Example</category>
+      <category>Language-Design</category>
+      <category>Announcement</category>
     </item>
     <item>
       <link>https://www.dyalog.com/blog/2023/01/structural-vs-mathematical-under</link>
@@ -1123,7 +1182,8 @@
       <pubDate>Thu, 26 Jan 2023 15:00:00 GMT</pubDate>
       <description>Morten Kromberg</description>
       <guid>https://www.dyalog.com/blog/2023/01/structural-vs-mathematical-under</guid>
-      <category>Design</category>
+      <category>Opinion</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/text-to-date</link>
@@ -1131,7 +1191,9 @@
       <pubDate>Mon, 23 Jan 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/text-to-date</guid>
-      <category>Example</category>
+      <category>Tutorial</category>
+      <category>Data-Query</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://mathspp.com/blog/connecting-python-and-dyalog-apl-with-sockets</link>
@@ -1139,7 +1201,8 @@
       <pubDate>Sat, 21 Jan 2023 15:00:00 GMT</pubDate>
       <description>Rodrigo Girão Serrão</description>
       <guid>https://mathspp.com/blog/connecting-python-and-dyalog-apl-with-sockets</guid>
-      <category>Example</category>
+      <category>Tutorial</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/an-issue-with-xml-revisited</link>
@@ -1147,7 +1210,8 @@
       <pubDate>Mon, 09 Jan 2023 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/an-issue-with-xml-revisited</guid>
-      <category>Design</category>
+      <category>Tutorial</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://medium.com/@solarbreeze69/an-apl-solution-to-logikers-vintage-computing-christmas-challenge-2022-d8d9751e6eb6</link>
@@ -1156,8 +1220,7 @@
       <pubDate>Wed, 28 Dec 2022 15:00:00 GMT</pubDate>
       <description>solarbreeze</description>
       <guid>https://medium.com/@solarbreeze69/an-apl-solution-to-logikers-vintage-computing-christmas-challenge-2022-d8d9751e6eb6</guid>
-      <category>Vintage</category>
-      <category>Challenge</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/anatomy-of-a-query-iii</link>
@@ -1165,8 +1228,8 @@
       <pubDate>Tue, 27 Dec 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/anatomy-of-a-query-iii</guid>
-      <category>Example</category>
-      <category>Idiom</category>
+      <category>Data-Query</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/anatomy-of-a-query-ii</link>
@@ -1174,8 +1237,8 @@
       <pubDate>Tue, 20 Dec 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/anatomy-of-a-query-ii</guid>
-      <category>Example</category>
-      <category>Idiom</category>
+      <category>Data-Query</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/secret-santa</link>
@@ -1183,7 +1246,8 @@
       <pubDate>Mon, 12 Dec 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/secret-santa</guid>
-      <category>Challenge</category>
+      <category>Tutorial</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/kap-solution-to-day-2-of-advent-of-code</link>
@@ -1191,7 +1255,8 @@
       <pubDate>Sun, 04 Dec 2022 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/kap-solution-to-day-2-of-advent-of-code</guid>
-      <category>Challenge</category>
+      <category>Puzzle-Solving</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://razetime.github.io/blog/2022/12/01/apl-willans.html</link>
@@ -1199,7 +1264,8 @@
       <pubDate>Thu, 01 Dec 2022 15:00:00 GMT</pubDate>
       <description>Raghu Ranganathan</description>
       <guid>https://razetime.github.io/blog/2022/12/01/apl-willans.html</guid>
-      <category>Example</category>
+      <category>Numeric-Math</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/parsing-markdown</link>
@@ -1207,7 +1273,8 @@
       <pubDate>Mon, 24 Oct 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/parsing-markdown</guid>
-      <category>Example</category>
+      <category>Tutorial</category>
+      <category>Web-GUI</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/anatomy-of-a-query</link>
@@ -1215,8 +1282,8 @@
       <pubDate>Sun, 23 Oct 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/anatomy-of-a-query</guid>
-      <category>Example</category>
-      <category>Idiom</category>
+      <category>Data-Query</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://optima-systems.co.uk/dyalog22-apl-user-meeting-portugal</link>
@@ -1225,7 +1292,6 @@
       <description>Paul Grosvenor</description>
       <guid>https://optima-systems.co.uk/dyalog22-apl-user-meeting-portugal</guid>
       <category>Announcement</category>
-      <category>Commentary</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/composerules-revisited</link>
@@ -1233,7 +1299,8 @@
       <pubDate>Fri, 07 Oct 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/composerules-revisited</guid>
-      <category>Example</category>
+      <category>Idioms-Techniques</category>
+      <category>Web-GUI</category>
     </item>
     <item>
       <link>https://razetime.github.io/blog/2022/10/03/apl-balanced-trees.html</link>
@@ -1241,7 +1308,8 @@
       <pubDate>Mon, 03 Oct 2022 15:00:00 GMT</pubDate>
       <description>Raghu Ranganathan</description>
       <guid>https://razetime.github.io/blog/2022/10/03/apl-balanced-trees.html</guid>
-      <category>Example</category>
+      <category>Tutorial</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://futhark-lang.org/blog/2022-10-03-futhark-on-arraycast.html</link>
@@ -1249,7 +1317,9 @@
       <pubDate>Mon, 03 Oct 2022 15:00:00 GMT</pubDate>
       <description>Troels Henriksen</description>
       <guid>https://futhark-lang.org/blog/2022-10-03-futhark-on-arraycast.html</guid>
-      <category>Commentary</category>
+      <category>Language-Design</category>
+      <category>Cross-Language</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/constructing-css-in-apl</link>
@@ -1257,7 +1327,8 @@
       <pubDate>Fri, 30 Sep 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/constructing-css-in-apl</guid>
-      <category>Example</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/threading-the-htmlrenderer</link>
@@ -1265,7 +1336,8 @@
       <pubDate>Thu, 22 Sep 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/threading-the-htmlrenderer</guid>
-      <category>Example</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/a-document-object-model-in-apl</link>
@@ -1273,8 +1345,9 @@
       <pubDate>Wed, 21 Sep 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/a-document-object-model-in-apl</guid>
-      <category>Example</category>
-      <category>Design</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>http://blog.vmchale.com/article/apl-different</link>
@@ -1282,7 +1355,9 @@
       <pubDate>Fri, 26 Aug 2022 15:00:00 GMT</pubDate>
       <description>Vanessa McHale</description>
       <guid>http://blog.vmchale.com/article/apl-different</guid>
-      <category>Commentary</category>
+      <category>Opinion</category>
+      <category>Idioms-Techniques</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://www.dyalog.com/blog/2022/08/maintaining-pynapl-part-2-apl-arrays-python-objects-and-json</link>
@@ -1291,7 +1366,9 @@
       <pubDate>Wed, 24 Aug 2022 15:00:00 GMT</pubDate>
       <description>Rodrigo Girão Serrão</description>
       <guid>https://www.dyalog.com/blog/2022/08/maintaining-pynapl-part-2-apl-arrays-python-objects-and-json</guid>
-      <category>Anecdote</category>
+      <category>Cross-Language</category>
+      <category>Tutorial</category>
+      <category>Data-Query</category>
     </item>
     <item>
       <link>http://apl2000.com</link>
@@ -1307,8 +1384,8 @@
       <pubDate>Sat, 06 Aug 2022 15:00:00 GMT</pubDate>
       <description>Felix Flath</description>
       <guid>https://isaac-flath.github.io/APL-Exploration/posts/knapsack2.html</guid>
-      <category>Example</category>
-      <category>Challenge</category>
+      <category>Tutorial</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://isaac-flath.github.io/APL-Exploration/posts/knapsack.html</link>
@@ -1316,8 +1393,8 @@
       <pubDate>Sat, 06 Aug 2022 15:00:00 GMT</pubDate>
       <description>Felix Flath</description>
       <guid>https://isaac-flath.github.io/APL-Exploration/posts/knapsack.html</guid>
-      <category>Example</category>
-      <category>Challenge</category>
+      <category>Tutorial</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/on-control-structures</link>
@@ -1325,7 +1402,9 @@
       <pubDate>Mon, 01 Aug 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/on-control-structures</guid>
-      <category>Design</category>
+      <category>Opinion</category>
+      <category>Language-Design</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/control-structures-in-kap</link>
@@ -1333,7 +1412,9 @@
       <pubDate>Sat, 23 Jul 2022 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/control-structures-in-kap</guid>
-      <category>Design</category>
+      <category>Language-Design</category>
+      <category>Opinion</category>
+      <category>Interpreter-Internals</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/leetcode-601</link>
@@ -1341,7 +1422,8 @@
       <pubDate>Sat, 09 Jul 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/leetcode-601</guid>
-      <category>Challenge</category>
+      <category>Data-Query</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/trains</link>
@@ -1349,7 +1431,8 @@
       <pubDate>Fri, 08 Jul 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/trains</guid>
-      <category>Pointfree</category>
+      <category>Idioms-Techniques</category>
+      <category>Data-Query</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/leetcode-569</link>
@@ -1357,7 +1440,9 @@
       <pubDate>Thu, 07 Jul 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/leetcode-569</guid>
-      <category>Challenge</category>
+      <category>Data-Query</category>
+      <category>Puzzle-Solving</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/leetcode-571</link>
@@ -1365,7 +1450,8 @@
       <pubDate>Wed, 06 Jul 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/leetcode-571</guid>
-      <category>Challenge</category>
+      <category>Data-Query</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/leetcode-262-trips-and-users</link>
@@ -1373,7 +1459,8 @@
       <pubDate>Sun, 26 Jun 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/leetcode-262-trips-and-users</guid>
-      <category>Challenge</category>
+      <category>Data-Query</category>
+      <category>Puzzle-Solving</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/leetcode-185</link>
@@ -1381,7 +1468,9 @@
       <pubDate>Sat, 25 Jun 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/leetcode-185</guid>
-      <category>Challenge</category>
+      <category>Data-Query</category>
+      <category>Puzzle-Solving</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://vector.org.uk/a-vendor-agnostic-logo-for-apl</link>
@@ -1397,7 +1486,7 @@
       <pubDate>Wed, 15 Jun 2022 15:00:00 GMT</pubDate>
       <description>Justin Dowdy</description>
       <guid>https://github.com/justin2004/weblog/blob/master/using_apl/README.md</guid>
-      <category>Example</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/operators-in-a-dsl</link>
@@ -1405,7 +1494,9 @@
       <pubDate>Sat, 28 May 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/operators-in-a-dsl</guid>
-      <category>Idiom</category>
+      <category>Language-Design</category>
+      <category>Opinion</category>
+      <category>Data-Query</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/commentary-on-array-cast</link>
@@ -1413,7 +1504,7 @@
       <pubDate>Wed, 18 May 2022 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/commentary-on-array-cast</guid>
-      <category>Commentary</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.dyalog.com/blog/2022/05/maintaining-pynapl-part-1-the-beginning</link>
@@ -1421,7 +1512,7 @@
       <pubDate>Mon, 09 May 2022 15:00:00 GMT</pubDate>
       <description>Rodrigo Girão Serrão</description>
       <guid>https://www.dyalog.com/blog/2022/05/maintaining-pynapl-part-1-the-beginning</guid>
-      <category>Anecdote</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://mathspp.com/blog/solving-wordle-with-apl</link>
@@ -1429,8 +1520,8 @@
       <pubDate>Mon, 28 Mar 2022 15:00:00 GMT</pubDate>
       <description>Rodrigo Girão Serrão</description>
       <guid>https://mathspp.com/blog/solving-wordle-with-apl</guid>
-      <category>Example</category>
-      <category>Challenge</category>
+      <category>Puzzle-Solving</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://mathspp.com/blog/why-apl-is-a-language-worth-knowing</link>
@@ -1438,7 +1529,8 @@
       <pubDate>Thu, 24 Mar 2022 15:00:00 GMT</pubDate>
       <description>Rodrigo Girão Serrão</description>
       <guid>https://mathspp.com/blog/why-apl-is-a-language-worth-knowing</guid>
-      <category>Commentary</category>
+      <category>Opinion</category>
+      <category>Cross-Language</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/lazy-evaluation-helping-implementation-of-transform-by-mask-in-kap</link>
@@ -1447,7 +1539,8 @@
       <pubDate>Sun, 13 Mar 2022 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/lazy-evaluation-helping-implementation-of-transform-by-mask-in-kap</guid>
-      <category>Design</category>
+      <category>Interpreter-Internals</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://blog.dhsdevelopments.com/an-example-of-lazy-evaluation-in-kap</link>
@@ -1455,7 +1548,8 @@
       <pubDate>Sat, 12 Mar 2022 15:00:00 GMT</pubDate>
       <description>Elias Mårtenson</description>
       <guid>https://blog.dhsdevelopments.com/an-example-of-lazy-evaluation-in-kap</guid>
-      <category>Example</category>
+      <category>Interpreter-Internals</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://outerproduct.net/2022-03-07_death-to-%E2%97%8B.html</link>
@@ -1463,7 +1557,8 @@
       <pubDate>Mon, 07 Mar 2022 15:00:00 GMT</pubDate>
       <description>Moonchild</description>
       <guid>https://outerproduct.net/2022-03-07_death-to-%E2%97%8B.html</guid>
-      <category>Design</category>
+      <category>Language-Design</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/session-configuration</link>
@@ -1471,7 +1566,8 @@
       <pubDate>Sun, 06 Mar 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/session-configuration</guid>
-      <category>Design</category>
+      <category>Language-Design</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/a-new-workspace-file-format</link>
@@ -1479,7 +1575,7 @@
       <pubDate>Sat, 26 Feb 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/a-new-workspace-file-format</guid>
-      <category>Design</category>
+      <category>Language-Design</category>
     </item>
     <item>
       <link>https://mathspp.com/blog/til/034</link>
@@ -1487,7 +1583,8 @@
       <pubDate>Wed, 23 Feb 2022 15:00:00 GMT</pubDate>
       <description>Rodrigo Girão Serrão</description>
       <guid>https://mathspp.com/blog/til/034</guid>
-      <category>Mathematics</category>
+      <category>Tutorial</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://mathspp.com/blog/til/033</link>
@@ -1495,7 +1592,8 @@
       <pubDate>Tue, 22 Feb 2022 15:00:00 GMT</pubDate>
       <description>Rodrigo Girão Serrão</description>
       <guid>https://mathspp.com/blog/til/033</guid>
-      <category>Mathematics</category>
+      <category>Tutorial</category>
+      <category>Numeric-Math</category>
     </item>
     <item>
       <link>https://github.com/justin2004/weblog/blob/master/a_random_permutation/README.md</link>
@@ -1503,8 +1601,8 @@
       <pubDate>Thu, 17 Feb 2022 15:00:00 GMT</pubDate>
       <description>Justin Dowdy</description>
       <guid>https://github.com/justin2004/weblog/blob/master/a_random_permutation/README.md</guid>
-      <category>Example</category>
-      <category>Anecdote</category>
+      <category>Idioms-Techniques</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/aaronhsuquote</link>
@@ -1512,7 +1610,7 @@
       <pubDate>Thu, 27 Jan 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/aaronhsuquote</guid>
-      <category>Commentary</category>
+      <category>Opinion</category>
     </item>
     <item>
       <link>https://www.toolofthought.com/posts/vfi-with-csv</link>
@@ -1520,8 +1618,8 @@
       <pubDate>Tue, 25 Jan 2022 15:00:00 GMT</pubDate>
       <description>Paul Mansour</description>
       <guid>https://www.toolofthought.com/posts/vfi-with-csv</guid>
-      <category>Example</category>
-      <category>Idiom</category>
+      <category>Tutorial</category>
+      <category>Data-Query</category>
     </item>
     <item>
       <link>https://mathspp.com/blog/til/021</link>
@@ -1529,7 +1627,8 @@
       <pubDate>Mon, 10 Jan 2022 15:00:00 GMT</pubDate>
       <description>Rodrigo Girão Serrã</description>
       <guid>https://mathspp.com/blog/til/021</guid>
-      <category>Mathematics</category>
+      <category>Numeric-Math</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://palaiologos.rocks/posts/linalg-apl</link>
@@ -1537,7 +1636,8 @@
       <pubDate>Mon, 10 Jan 2022 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
       <guid>https://palaiologos.rocks/posts/linalg-apl</guid>
-      <category>Mathematics</category>
+      <category>Numeric-Math</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://palaiologos.rocks/posts/poly-root-apl</link>
@@ -1545,7 +1645,8 @@
       <pubDate>Sun, 09 Jan 2022 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
       <guid>https://palaiologos.rocks/posts/poly-root-apl</guid>
-      <category>Mathematics</category>
+      <category>Numeric-Math</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://palaiologos.rocks/posts/taylor-apl</link>
@@ -1553,7 +1654,8 @@
       <pubDate>Thu, 06 Jan 2022 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
       <guid>https://palaiologos.rocks/posts/taylor-apl</guid>
-      <category>Mathematics</category>
+      <category>Numeric-Math</category>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://optima-systems.co.uk/creating-a-graphical-user-interface-gui-in-dyalog-apl-part-1</link>
@@ -1562,7 +1664,8 @@
       <pubDate>Fri, 28 May 2021 15:00:00 GMT</pubDate>
       <description>Sam Gutsell</description>
       <guid>https://optima-systems.co.uk/creating-a-graphical-user-interface-gui-in-dyalog-apl-part-1</guid>
-      <category>Example</category>
+      <category>Web-GUI</category>
+      <category>Tutorial</category>
     </item>
   </channel>
 </rss>


### PR DESCRIPTION
Reworks the tag vocabulary and re-tags all **184 posts**, then regenerates `rss.xml`.

### Why
The old 15-tag set was unbalanced:
- **Example** was on 36% of posts — too broad to filter on.
- **Humour (1), Pointfree (2), Testing (3), Education (3)** were near-singletons.
- Example/Idiom/Challenge and Design/Commentary overlapped heavily.

### New taxonomy (11 tags, two facets)
Each post carries ~1 purpose tag + ~1 domain tag (avg 2.0 tags/post; every post covered).

| Tag | Count | % |
|---|---:|---:|
| Tutorial | 74 | 40% |
| Opinion | 39 | 21% |
| Language-Design | 37 | 20% |
| Puzzle-Solving | 33 | 18% |
| Idioms-Techniques | 33 | 18% |
| Web-GUI | 30 | 16% |
| Numeric-Math | 30 | 16% |
| Interpreter-Internals | 29 | 16% |
| Cross-Language | 24 | 13% |
| Data-Query | 22 | 12% |
| Announcement | 18 | 10% |

**Purpose:** Tutorial / Puzzle-Solving / Opinion / Announcement · **Domain:** Interpreter-Internals / Web-GUI / Numeric-Math / Cross-Language / Data-Query · **Technique:** Idioms-Techniques / Language-Design.

Every new tag lands in the 10–40% band, no singletons, no orphaned posts. Tags were assigned by reading each post's actual content, not just its title.

**Retired:** Example (split), Idiom→Idioms-Techniques, Challenge→Puzzle-Solving, Design→Language-Design/Opinion, Commentary→Opinion/Cross-Language, Implementation→Interpreter-Internals, Mathematics→Numeric-Math, Language-comparison→Cross-Language, and Pointfree/Testing/Education/Anecdote/Humour/Vintage folded into broader homes.

The filter checkboxes are generated from the `class=` values at runtime, so no other code changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)