### PR TITLE
Add English APL articles from APL Journal 2022–2024

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,16 @@
     2025-06-04, Paul Mansour
   </article>
 
+  <article class="Tutorial">
+    <a href="https://apl-germany.de/wp-content/uploads/2025/04/APLJournal2024.pdf#page=20">Migration from APL+Win to Dyalog</a>
+    2025-04-11, Markos Mitsos
+  </article>
+
+  <article class="Tutorial Opinion">
+    <a href="https://apl-germany.de/wp-content/uploads/2025/04/APLJournal2024.pdf#page=44">Development in Dyalog APL with Modern Tools</a>
+    2025-04-11, Kai Jäger
+  </article>
+
   <article class="Announcement Interpreter-Internals Language-Design">
     <a href="https://blog.rubenverg.com/tinyapl_15_extra_arguments">TinyAPL part 15: Extra Arguments</a>
     2025-03-13, Madeline Vergani
@@ -363,6 +373,11 @@
   <article class="Web-GUI Tutorial">
     <a href="https://www.toolofthought.com/posts/modal-dialog-boxes-1">Modal Dialog Boxes 1: Alert</a>
     2024-04-29, Paul Mansour
+  </article>
+
+  <article class="Numeric-Math Idioms-Techniques">
+    <a href="https://apl-germany.de/wp-content/uploads/2024/04/APL_Journal_2023.pdf#page=15">Seemingly Impossible APL Programs</a>
+    2024-04-29, Kamila Szewczyk
   </article>
 
   <article class="Tutorial Numeric-Math">
@@ -653,6 +668,16 @@
   <article class="Idioms-Techniques Numeric-Math">
     <a href="https://www.toolofthought.com/posts/grade-up-of-grade-down">Grade Down of Grade Up</a>
     2023-03-21, Paul Mansour
+  </article>
+
+  <article class="Announcement">
+    <a href="https://apl-germany.de/wp-content/uploads/2023/03/APL_Journal_2022.pdf#page=40">APL2Plus™: A New Mainframe Offering</a>
+    2023-03-14, James A. Brown
+  </article>
+
+  <article class="Tutorial">
+    <a href="https://apl-germany.de/wp-content/uploads/2023/03/APL_Journal_2022.pdf#page=42">Management of Dyalog APL workspaces</a>
+    2023-03-14, Markos Mitsos
   </article>
 
   <article class="Announcement Puzzle-Solving">

--- a/rss.xml
+++ b/rss.xml
@@ -269,6 +269,23 @@
       <category>Cross-Language</category>
     </item>
     <item>
+      <link>https://apl-germany.de/wp-content/uploads/2025/04/APLJournal2024.pdf#page=20</link>
+      <title>Migration from APL+Win to Dyalog</title>
+      <pubDate>Fri, 11 Apr 2025 15:00:00 GMT</pubDate>
+      <description>Markos Mitsos</description>
+      <guid>https://apl-germany.de/wp-content/uploads/2025/04/APLJournal2024.pdf#page=20</guid>
+      <category>Tutorial</category>
+    </item>
+    <item>
+      <link>https://apl-germany.de/wp-content/uploads/2025/04/APLJournal2024.pdf#page=44</link>
+      <title>Development in Dyalog APL with Modern Tools</title>
+      <pubDate>Fri, 11 Apr 2025 15:00:00 GMT</pubDate>
+      <description>Kai Jäger</description>
+      <guid>https://apl-germany.de/wp-content/uploads/2025/04/APLJournal2024.pdf#page=44</guid>
+      <category>Tutorial</category>
+      <category>Opinion</category>
+    </item>
+    <item>
       <link>https://blog.rubenverg.com/tinyapl_15_extra_arguments</link>
       <title>TinyAPL part 15: Extra Arguments</title>
       <pubDate>Thu, 13 Mar 2025 15:00:00 GMT</pubDate>
@@ -592,6 +609,15 @@
       <guid>https://www.toolofthought.com/posts/modal-dialog-boxes-1</guid>
       <category>Web-GUI</category>
       <category>Tutorial</category>
+    </item>
+    <item>
+      <link>https://apl-germany.de/wp-content/uploads/2024/04/APL_Journal_2023.pdf#page=15</link>
+      <title>Seemingly Impossible APL Programs</title>
+      <pubDate>Mon, 29 Apr 2024 15:00:00 GMT</pubDate>
+      <description>Kamila Szewczyk</description>
+      <guid>https://apl-germany.de/wp-content/uploads/2024/04/APL_Journal_2023.pdf#page=15</guid>
+      <category>Numeric-Math</category>
+      <category>Idioms-Techniques</category>
     </item>
     <item>
       <link>https://bl0v3.com/Blog/raymarching-in-dyalog-apl/</link>
@@ -1115,6 +1141,22 @@
       <guid>https://www.toolofthought.com/posts/grade-up-of-grade-down</guid>
       <category>Idioms-Techniques</category>
       <category>Numeric-Math</category>
+    </item>
+    <item>
+      <link>https://apl-germany.de/wp-content/uploads/2023/03/APL_Journal_2022.pdf#page=40</link>
+      <title>APL2Plus™: A New Mainframe Offering</title>
+      <pubDate>Tue, 14 Mar 2023 15:00:00 GMT</pubDate>
+      <description>James A. Brown</description>
+      <guid>https://apl-germany.de/wp-content/uploads/2023/03/APL_Journal_2022.pdf#page=40</guid>
+      <category>Announcement</category>
+    </item>
+    <item>
+      <link>https://apl-germany.de/wp-content/uploads/2023/03/APL_Journal_2022.pdf#page=42</link>
+      <title>Management of Dyalog APL workspaces</title>
+      <pubDate>Tue, 14 Mar 2023 15:00:00 GMT</pubDate>
+      <description>Markos Mitsos</description>
+      <guid>https://apl-germany.de/wp-content/uploads/2023/03/APL_Journal_2022.pdf#page=42</guid>
+      <category>Tutorial</category>
     </item>
     <item>
       <link>https://www.sacrideo.us/2023-apl-problem-solving-competition</link>


### PR DESCRIPTION
Adds the articles from the last three **APL Journal** issues (APL Germany e.V.) that are **both** (1) in English **and** (2) actually about APL, then regenerates `rss.xml`.

Each link points at the PDF's **logical page** via `#page=n` (physical PDF page, which runs +2 vs. the printed page number in every issue).

| Issue | Article | Author | Tags | `#page` |
|---|---|---|---|---|
| 2022 | APL2Plus™: A New Mainframe Offering | James A. Brown | Announcement | 40 |
| 2022 | Management of Dyalog APL workspaces | Markos Mitsos | Tutorial | 42 |
| 2023 | Seemingly Impossible APL Programs | Kamila Szewczyk | Numeric-Math, Idioms-Techniques | 15 |
| 2024 | Migration from APL+Win to Dyalog | Markos Mitsos | Tutorial | 20 |
| 2024 | Development in Dyalog APL with Modern Tools | Kai Jäger | Tutorial, Opinion | 44 |

**Excluded**, per the two criteria:
- *German* — Vedische Mathematik, Zeit und Raum, Analog- und Hybridrechnen im 21. Jahrhundert, Euklids Elemente interaktiv, Eine Schnittstelle zu Excel via APL2-COM, Private PKW in Deutschland, **Neue Funktionen in GNU APL**.
- *English but not about APL* — **Typesetting external program code and its output: hvextern**, Acronyms.

**Dates:** each article carries its issue's publication date (the PDF's creation timestamp): 2022 → 2023-03-14, 2023 → 2024-04-29, 2024 → 2025-04-11. Easy to change if you'd rather date them by the cover year.

🤖 Generated with [Claude Code](https://claude.com/claude-code)