### PR TITLE
Add a checker for new candidate articles from known sources

### DIFF
--- a/.github/workflows/check-sources.yml
+++ b/.github/workflows/check-sources.yml
@@ -1,0 +1,69 @@
+name: Check known sources for new articles
+
+# Periodically look for articles published by our known sources that are not yet
+# listed on apl.news, and collect them into a single GitHub issue for triage.
+# Every hit is only a *candidate*: a human still decides whether it is in English
+# and actually about APL before adding it.
+
+on:
+  schedule:
+    - cron: '17 6 * * 1'   # every Monday at 06:17 UTC
+  workflow_dispatch: {}     # allow manual runs from the Actions tab
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: check-sources
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - id: check
+        name: Scan sources
+        run: node scripts/check-sources.mjs --out "$RUNNER_TEMP/candidates.md"
+
+      - name: Open or update the candidates issue
+        if: ${{ steps.check.outputs.count != '0' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync(process.env.RUNNER_TEMP + '/candidates.md', 'utf8');
+            const title = '🔎 Candidate articles from known sources';
+            const label = 'source-candidates';
+
+            // Make sure the label exists.
+            try {
+              await github.rest.issues.getLabel({ ...context.repo, name: label });
+            } catch {
+              await github.rest.issues.createLabel({
+                ...context.repo, name: label, color: '0e8a16',
+                description: 'Auto-detected articles from known sources, pending triage',
+              });
+            }
+
+            // Reuse the existing open issue if there is one, else create it.
+            const open = await github.rest.issues.listForRepo({
+              ...context.repo, state: 'open', labels: label, per_page: 1,
+            });
+            if (open.data.length) {
+              await github.rest.issues.update({
+                ...context.repo, issue_number: open.data[0].number, title, body,
+              });
+              core.info(`Updated issue #${open.data[0].number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                ...context.repo, title, labels: [label], body,
+              });
+              core.info(`Created issue #${created.data.number}`);
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+candidates.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,69 @@
+# Source checker
+
+`check-sources.mjs` looks for articles published by our **known sources** that are
+not yet listed in [`../index.html`](../index.html), so we stop relying solely on
+noticing new posts by hand.
+
+Every hit is a **candidate**, not a decision: it only means a known source
+published something we haven't listed. A human still has to confirm the article
+is (1) in English and (2) actually about APL before adding it — the same bar we
+apply manually. Brand-new sources we've never seen still have to be discovered by
+hand; this only watches sources we already know.
+
+## Running it
+
+Requires Node 20+ (uses the built-in `fetch`; no dependencies).
+
+```sh
+node scripts/check-sources.mjs             # human-readable report
+node scripts/check-sources.mjs --out FILE  # also write a Markdown report to FILE
+node scripts/check-sources.mjs --json      # machine-readable JSON on stdout
+```
+
+It reads `sources.json`, fetches each source, extracts article links, and prints
+the ones whose URL is not already in `index.html` (comparison ignores scheme,
+`www.`, query, fragment and trailing slash).
+
+## Automation
+
+[`.github/workflows/check-sources.yml`](../.github/workflows/check-sources.yml)
+runs it every Monday (and on demand via *workflow_dispatch*). When there are
+candidates it opens — or updates — a single issue labelled `source-candidates`
+containing a checklist grouped by source.
+
+## Configuring sources — `sources.json`
+
+`sources` is an array; each entry is one of:
+
+- **feed** — an RSS or Atom feed:
+  ```json
+  { "name": "Dyalog blog", "type": "feed", "url": "https://www.dyalog.com/blog/feed/" }
+  ```
+- **scrape** — an HTML listing page whose article links match `pattern` (a
+  regex tested against each `href`, resolved against the page's origin):
+  ```json
+  { "name": "Tool of Thought", "type": "scrape",
+    "url": "https://www.toolofthought.com/", "pattern": "/posts/[a-z0-9][a-z0-9-]*" }
+  ```
+
+Optional keys on any source:
+
+- `exclude` — regex; drop links whose `href` matches (e.g. tag/category pages).
+- `filter` — regex; **keep only** items whose URL or title matches. Use it to
+  narrow multi-topic blogs to APL (e.g. `"apl"`). Both `filter` and `exclude`
+  are matched case-insensitively.
+
+### Tips
+
+- **Prefer an APL-tag endpoint** when a source offers one — it removes noise at
+  the source. Examples in use: `jcarroll.com.au/tags/apl/index.xml`,
+  `sacrideo.us/tag/apl/feed/`, `mathspp.com/blog/tag:apl`,
+  `iczelia.net/blog/tag/apl/`. Blogger blogs expose per-label Atom feeds at
+  `…/feeds/posts/default/-/<LABEL>` (URL-encode the label).
+- For a general-interest blog with no tag endpoint, use the plain feed plus
+  `"filter": "apl"`.
+- `manual` lists known sources with **no** reliable automated endpoint (e.g. the
+  annual APL Journal PDF, one-off GitHub READMEs). Check those by hand.
+
+To add a source: append an entry to `sources.json` and run the script locally to
+confirm it returns sensible candidates.

--- a/scripts/check-sources.mjs
+++ b/scripts/check-sources.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+// Detect candidate articles from known sources that are not yet listed in index.html.
+//
+// Usage:
+//   node scripts/check-sources.mjs            # human-readable report to stdout
+//   node scripts/check-sources.mjs --out FILE # also write a Markdown report to FILE
+//   node scripts/check-sources.mjs --json     # emit machine-readable JSON to stdout
+//
+// "Candidate" is deliberate: a hit only means the source published something we
+// haven't listed — it still needs a human to judge whether it is on-topic.
+// Sources are configured in scripts/sources.json (feeds and HTML-scrape specs).
+//
+// No dependencies: uses Node 20+ global fetch. Exit code is always 0 (a source
+// that errors is reported inline, not treated as a build failure).
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(HERE, '..');
+const UA = 'apl.news-source-checker/1.0 (+https://github.com/abrudz/apl.news)';
+const TIMEOUT_MS = 20000;
+
+const args = process.argv.slice(2);
+const outFile = args.includes('--out') ? args[args.indexOf('--out') + 1] : null;
+const asJson = args.includes('--json');
+
+// ---------- helpers ----------
+
+// Canonical form for comparing URLs: drop scheme, leading www., query, fragment,
+// and any trailing slash; lowercase the host. Keeps path case (some slugs care).
+function normalize(u) {
+  try {
+    const url = new URL(u);
+    const host = url.host.replace(/^www\./i, '').toLowerCase();
+    const path = url.pathname.replace(/\/+$/, '');
+    return host + path;
+  } catch {
+    return String(u).trim().toLowerCase();
+  }
+}
+
+// A cleaned, display/storage-ready absolute URL (no query/fragment/trailing slash
+// noise), so it can be pasted straight into index.html.
+function cleanUrl(u) {
+  try {
+    const url = new URL(u);
+    url.hash = '';
+    url.search = '';
+    let s = url.toString();
+    return s.replace(/\/$/, m => (url.pathname === '/' ? m : ''));
+  } catch {
+    return u;
+  }
+}
+
+function decodeEntities(s) {
+  return (s || '')
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&#0?39;|&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function titleFromSlug(u) {
+  try {
+    const seg = new URL(u).pathname.replace(/\/+$/, '').split('/').pop() || '';
+    return seg.replace(/\.(html?|xml)$/i, '')
+      .replace(/^\d{4}-\d{2}-\d{2}-/, '')
+      .replace(/[-_]+/g, ' ').trim();
+  } catch { return ''; }
+}
+
+async function fetchOnce(url) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      redirect: 'follow',
+      signal: ctrl.signal,
+      headers: { 'user-agent': UA, accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, text/html; q=0.9, */*; q=0.8' },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.text();
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+// Retry a couple of times: feeds behind CDNs (e.g. 503/429) and flaky TLS are common.
+async function fetchText(url, attempts = 3) {
+  let last;
+  for (let i = 0; i < attempts; i++) {
+    try { return await fetchOnce(url); }
+    catch (e) {
+      last = e;
+      if (i < attempts - 1) await new Promise(r => setTimeout(r, 800 * (i + 1)));
+    }
+  }
+  throw last;
+}
+
+// ---------- extractors ----------
+
+// RSS <item>…<link>URL</link>…<title>…</title>  and  Atom <entry>…<link href="URL"/>…<title>…
+function parseFeed(xml) {
+  const out = [];
+  const blocks = xml.match(/<(item|entry)\b[\s\S]*?<\/\1>/gi) || [];
+  for (const b of blocks) {
+    let link = null;
+    const rss = b.match(/<link>\s*([\s\S]*?)\s*<\/link>/i);
+    if (rss) link = decodeEntities(rss[1]);
+    if (!link) {
+      // Atom: prefer rel="alternate" (or no rel), type text/html
+      const alts = [...b.matchAll(/<link\b([^>]*)\/?>/gi)].map(m => m[1]);
+      const pick = alts.find(a => /rel=["']?alternate/i.test(a)) || alts.find(a => !/rel=/i.test(a)) || alts[0];
+      if (pick) { const h = pick.match(/href=["']([^"']+)["']/i); if (h) link = h[1]; }
+    }
+    if (!link) continue;
+    const tm = b.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
+    out.push({ url: link.trim(), title: tm ? decodeEntities(tm[1]) : '' });
+  }
+  return out;
+}
+
+// Scrape: find hrefs matching `pattern`, resolve against the listing page origin.
+function parseScrape(html, baseUrl, patternSrc, excludeSrc) {
+  const origin = new URL(baseUrl).origin;
+  const hrefs = [...html.matchAll(/href=["']([^"']+)["']/gi)].map(m => m[1]);
+  const pat = new RegExp(patternSrc);
+  const exc = excludeSrc ? new RegExp(excludeSrc, 'i') : null;
+  const seen = new Set();
+  const out = [];
+  for (const h of hrefs) {
+    if (!pat.test(h)) continue;
+    if (exc && exc.test(h)) continue;
+    let abs;
+    try { abs = new URL(h, origin).toString(); } catch { continue; }
+    const key = normalize(abs);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ url: abs, title: titleFromSlug(abs) });
+  }
+  return out;
+}
+
+// ---------- main ----------
+
+const indexHtml = await readFile(join(ROOT, 'index.html'), 'utf8');
+const config = JSON.parse(await readFile(join(HERE, 'sources.json'), 'utf8'));
+
+const seen = new Set(
+  [...indexHtml.matchAll(/<a\s+href=["'](https?:\/\/[^"']+)["']/gi)].map(m => normalize(m[1])),
+);
+
+const results = []; // { name, candidates:[{url,title}], error }
+for (const s of config.sources) {
+  try {
+    const text = await fetchText(s.url);
+    let items = s.type === 'feed'
+      ? parseFeed(text)
+      : parseScrape(text, s.url, s.pattern, s.exclude);
+    if (s.filter) {
+      const f = new RegExp(s.filter, 'i');
+      items = items.filter(it => f.test(it.url) || f.test(it.title));
+    }
+    const fresh = [];
+    const dedupe = new Set();
+    for (const it of items) {
+      const key = normalize(it.url);
+      if (seen.has(key) || dedupe.has(key)) continue;
+      dedupe.add(key);
+      fresh.push({ url: cleanUrl(it.url), title: it.title || titleFromSlug(it.url) });
+    }
+    results.push({ name: s.name, candidates: fresh });
+  } catch (e) {
+    results.push({ name: s.name, candidates: [], error: e.message || String(e) });
+  }
+}
+
+const totalCandidates = results.reduce((n, r) => n + r.candidates.length, 0);
+const errored = results.filter(r => r.error);
+
+// ---------- output ----------
+
+function toMarkdown() {
+  const lines = [];
+  lines.push('<!-- apl-news-source-checker -->');
+  lines.push(`### ${totalCandidates} candidate article${totalCandidates === 1 ? '' : 's'} from known sources`);
+  lines.push('');
+  lines.push('Each link is a post from a known source that is **not yet listed** on apl.news. A candidate still needs a human to confirm it is in English and actually about APL before adding it.');
+  lines.push('');
+  for (const r of results) {
+    if (!r.candidates.length) continue;
+    lines.push(`#### ${r.name}`);
+    for (const c of r.candidates) lines.push(`- [ ] [${c.title || c.url}](${c.url})`);
+    lines.push('');
+  }
+  if (errored.length) {
+    lines.push('#### ⚠ Sources that could not be checked');
+    for (const r of errored) lines.push(`- ${r.name}: \`${r.error}\``);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+if (asJson) {
+  process.stdout.write(JSON.stringify({ totalCandidates, results }, null, 2) + '\n');
+} else {
+  // Human-readable console report
+  for (const r of results) {
+    if (r.error) { console.log(`⚠  ${r.name}: ${r.error}`); continue; }
+    if (!r.candidates.length) { console.log(`   ${r.name}: up to date`); continue; }
+    console.log(`\n★  ${r.name}: ${r.candidates.length} candidate(s)`);
+    for (const c of r.candidates) console.log(`     • ${c.title || ''}\n       ${c.url}`);
+  }
+  console.log(`\n${totalCandidates} candidate(s) total across ${config.sources.length} sources` +
+    (errored.length ? `; ${errored.length} source(s) errored` : ''));
+}
+
+const md = toMarkdown();
+if (outFile) await writeFile(outFile, md + '\n', 'utf8');
+
+// Expose count to GitHub Actions if running there.
+if (process.env.GITHUB_OUTPUT) {
+  await writeFile(process.env.GITHUB_OUTPUT, `count=${totalCandidates}\n`, { flag: 'a' });
+}

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "Source registry for check-sources.mjs. Each entry is either a 'feed' (RSS/Atom) or a 'scrape' (fetch an HTML listing page and extract article links matching `pattern`, resolved against the page's origin). Optional `exclude` drops matching URLs; optional `filter` keeps ONLY items whose URL or title matches it (to narrow multi-topic blogs to APL). Prefer APL-tag-filtered endpoints where a source offers them. See README.md.",
+  "sources": [
+    { "name": "Tool of Thought (Paul Mansour)", "type": "scrape", "url": "https://www.toolofthought.com/", "pattern": "/posts/[a-z0-9][a-z0-9-]*" },
+    { "name": "dhsdevelopments / KAP (Elias Mårtenson)", "type": "feed", "url": "https://blog.dhsdevelopments.com/feed/" },
+    { "name": "TinyAPL (Ruben Verg)", "type": "feed", "url": "https://blog.rubenverg.com/feed" },
+    { "name": "Dyalog blog", "type": "feed", "url": "https://www.dyalog.com/blog/feed/" },
+    { "name": "Jonathan Carroll (APL tag)", "type": "feed", "url": "https://jcarroll.com.au/tags/apl/index.xml" },
+    { "name": "sacrideo (Aaron Hsu, APL tag)", "type": "feed", "url": "https://www.sacrideo.us/tag/apl/feed/" },
+    { "name": "mathspp (Rodrigo Girão Serrão, APL tag)", "type": "scrape", "url": "https://mathspp.com/blog/tag:apl", "pattern": "/blog/[a-z0-9][a-z0-9/-]*", "exclude": "/blog/(problems|tags)(/|$)|/blog/(pydonts|til|twitter-threads)$" },
+    { "name": "Brandon Wilson", "type": "scrape", "url": "https://blog.wilsonb.com/", "pattern": "/posts/\\d{4}-\\d{2}-\\d{2}-[a-z0-9-]+\\.html" },
+    { "name": "loriculus (Rohan Prinja)", "type": "scrape", "url": "https://loriculus.org/blog/", "pattern": "/blog/[a-z0-9][a-z0-9-]*/", "exclude": "/blog/tag/" },
+    { "name": "iczelia / formerly palaiologos.rocks (Kamila Szewczyk, APL tag)", "type": "scrape", "url": "https://iczelia.net/blog/tag/apl/", "pattern": "/blog/[a-z0-9][a-z0-9-]*/", "exclude": "/blog/tag" },
+    { "name": "razetime (Raghu Ranganathan)", "type": "feed", "url": "https://razetime.github.io/feed.xml" },
+    { "name": "xpqz (Stefan Kruger)", "type": "feed", "url": "https://xpqz.github.io/feed.xml" },
+    { "name": "Veit Heller (APL only)", "type": "feed", "url": "https://blog.veitheller.de/feed.rss", "filter": "apl" },
+    { "name": "Graham Enos (APL only)", "type": "feed", "url": "https://grahamenos.com/atom.xml", "filter": "apl" },
+    { "name": "bl0v3", "type": "feed", "url": "https://bl0v3.com/atom.xml" },
+    { "name": "solarbreeze (Medium, APL only)", "type": "feed", "url": "https://medium.com/feed/@solarbreeze69", "filter": "apl" },
+    { "name": "But why is that? (Substack)", "type": "feed", "url": "https://butwhyisthat.substack.com/feed" },
+    { "name": "RareSchool (#APL label)", "type": "feed", "url": "https://blog.rareschool.com/feeds/posts/default/-/%23APL" },
+    { "name": "puntoblogspot (apl/j/k label)", "type": "feed", "url": "https://puntoblogspot.blogspot.com/feeds/posts/default/-/apl%2Fj%2Fk" }
+  ],
+  "manual": [
+    { "name": "APL Journal (APL Germany e.V.)", "url": "https://apl-germany.de/apl-journal/", "reason": "Annual PDF, not a feed. Check once a year and filter to English APL articles." },
+    { "name": "One-off / low-frequency sources", "url": "", "reason": "github.com READMEs, optima-systems.co.uk, apl2000.com, pitr.ca, blog.vmchale.com, homewithinnowhere.com, scharenbroch.dev, futhark-lang.org, outerproduct.net, isaac-flath.github.io, maxcan-code.github.io, ap29600.github.io — no reliable per-source APL feed; add as needed." }
+  ]
+}


### PR DESCRIPTION
Adds a script + scheduled GitHub Action that watches our **known sources** and flags articles not yet listed on apl.news, so we stop relying purely on noticing new posts by hand.

Every hit is a **candidate** — it only means a known source published something we haven't listed. A human still confirms it's in English and actually about APL before adding. (Never-seen-before sources still have to be found manually.)

### What's here
- **`scripts/check-sources.mjs`** — Node 20, zero dependencies (built-in `fetch`). Fetches each source, extracts article links, and prints those whose URL isn't already in `index.html` (comparison ignores scheme, `www.`, query, fragment, trailing slash). Retries transient CDN failures; a source that errors is reported inline, never fatal.
- **`scripts/sources.json`** — the source registry. Two mechanisms:
  - `feed` — RSS/Atom (covers ~13 sources)
  - `scrape` — an HTML listing page + a `pattern` regex (covers the feedless ones, incl. **toolofthought**, which has 68 articles and no feed)
  - optional `exclude` (drop tag/category links) and `filter` (keep only APL-matching items on multi-topic blogs)
- **`.github/workflows/check-sources.yml`** — runs weekly (Mondays) and on demand; when there are candidates it opens/updates a single `source-candidates` issue with a checklist grouped by source.
- **`scripts/README.md`** — usage + how to add a source.

### Noise control via APL-tag endpoints
Where a source offers an APL-only endpoint, the registry uses it: jcarroll `tags/apl/index.xml`, sacrideo `tag/apl/feed/`, mathspp `blog/tag:apl`, iczelia `blog/tag/apl/`. General blogs use a plain feed + `"filter": "apl"` (veitheller, Graham Enos, solarbreeze). This cut e.g. Graham Enos from 43 → 2 and mathspp from 52 → 20 real APL posts.

### New sources added
Per your tag URLs, added two Blogger sources via their per-label Atom feeds: **blog.rareschool.com** (`#APL`) and **puntoblogspot** (`apl/j/k`).

### Test run
Ran live against all 19 sources: **0 errors**, 109 candidates surfaced (the existing backlog — subsequent runs will be near-empty). `palaiologos.rocks` is covered under its new home **iczelia.net** (see the follow-up PR that repoints the existing links).

Notes:
- First issue will be large (it's the whole backlog); it shrinks after you triage.
- `mathspp` had no feed and a JS/category-based index, so it's scraped via its APL tag page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)