### PR TITLE
Repoint palaiologos.rocks links to iczelia.net

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@
   </article>
 
   <article class="Tutorial Numeric-Math">
-    <a href="https://palaiologos.rocks/posts/polygon-triangulation/">Triangulation of convex polygons</a>
+    <a href="https://iczelia.net/blog/polygon-triangulation/">Triangulation of convex polygons</a>
     2024-02-23, Kamila Szewczyk
   </article>
 
@@ -496,7 +496,7 @@
   </article>
 
   <article class="Puzzle-Solving Announcement">
-    <a href="https://palaiologos.rocks/posts/dan-baronets-microwave/">Dan Baronet’s Microwave</a>
+    <a href="https://iczelia.net/blog/dan-baronets-microwave/">Dan Baronet’s Microwave</a>
     2023-10-04, Kamila Szewczyk
   </article>
 
@@ -561,12 +561,12 @@
   </article>
   
   <article class="Numeric-Math Puzzle-Solving">
-    <a href="https://palaiologos.rocks/posts/avg/">The nested means problem</a>
+    <a href="https://iczelia.net/blog/avg/">The nested means problem</a>
     2023-08-13, Kamila Szewczyk
   </article>
 
   <article class="Interpreter-Internals Numeric-Math">
-    <a href="https://palaiologos.rocks/posts/lc-apl/">Journey to the Center of the Lambda Calculus</a>
+    <a href="https://iczelia.net/blog/lc-apl/">Journey to the Center of the Lambda Calculus</a>
     2023-08-13, Kamila Szewczyk
   </article>
 
@@ -971,17 +971,17 @@
   </article>
 
   <article class="Numeric-Math Tutorial">
-    <a href="https://palaiologos.rocks/posts/linalg-apl">Implementing the Faddeev-LeVerrier algorithm in APL</a>
+    <a href="https://iczelia.net/blog/linalg-apl/">Implementing the Faddeev-LeVerrier algorithm in APL</a>
     2022-01-10, Kamila Szewczyk
   </article>
   
   <article class="Numeric-Math Tutorial">
-    <a href="https://palaiologos.rocks/posts/poly-root-apl">Finding roots of a polynomial - numerical methods in APL </a>
+    <a href="https://iczelia.net/blog/poly-root-apl/">Finding roots of a polynomial - numerical methods in APL </a>
     2022-01-09, Kamila Szewczyk
   </article>
 
   <article class="Numeric-Math Tutorial">
-    <a href="https://palaiologos.rocks/posts/taylor-apl">Implementing Taylor Series in APL</a>
+    <a href="https://iczelia.net/blog/taylor-apl/">Implementing Taylor Series in APL</a>
     2022-01-06, Kamila Szewczyk
   </article>
 

--- a/rss.xml
+++ b/rss.xml
@@ -681,11 +681,11 @@
       <category>Cross-Language</category>
     </item>
     <item>
-      <link>https://palaiologos.rocks/posts/polygon-triangulation/</link>
+      <link>https://iczelia.net/blog/polygon-triangulation/</link>
       <title>Triangulation of convex polygons</title>
       <pubDate>Fri, 23 Feb 2024 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
-      <guid>https://palaiologos.rocks/posts/polygon-triangulation/</guid>
+      <guid>https://iczelia.net/blog/polygon-triangulation/</guid>
       <category>Tutorial</category>
       <category>Numeric-Math</category>
     </item>
@@ -831,11 +831,11 @@
       <category>Puzzle-Solving</category>
     </item>
     <item>
-      <link>https://palaiologos.rocks/posts/dan-baronets-microwave/</link>
+      <link>https://iczelia.net/blog/dan-baronets-microwave/</link>
       <title>Dan Baronet’s Microwave</title>
       <pubDate>Wed, 04 Oct 2023 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
-      <guid>https://palaiologos.rocks/posts/dan-baronets-microwave/</guid>
+      <guid>https://iczelia.net/blog/dan-baronets-microwave/</guid>
       <category>Puzzle-Solving</category>
       <category>Announcement</category>
     </item>
@@ -949,20 +949,20 @@
       <category>Tutorial</category>
     </item>
     <item>
-      <link>https://palaiologos.rocks/posts/avg/</link>
+      <link>https://iczelia.net/blog/avg/</link>
       <title>The nested means problem</title>
       <pubDate>Sun, 13 Aug 2023 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
-      <guid>https://palaiologos.rocks/posts/avg/</guid>
+      <guid>https://iczelia.net/blog/avg/</guid>
       <category>Numeric-Math</category>
       <category>Puzzle-Solving</category>
     </item>
     <item>
-      <link>https://palaiologos.rocks/posts/lc-apl/</link>
+      <link>https://iczelia.net/blog/lc-apl/</link>
       <title>Journey to the Center of the Lambda Calculus</title>
       <pubDate>Sun, 13 Aug 2023 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
-      <guid>https://palaiologos.rocks/posts/lc-apl/</guid>
+      <guid>https://iczelia.net/blog/lc-apl/</guid>
       <category>Interpreter-Internals</category>
       <category>Numeric-Math</category>
     </item>
@@ -1682,29 +1682,29 @@
       <category>Tutorial</category>
     </item>
     <item>
-      <link>https://palaiologos.rocks/posts/linalg-apl</link>
+      <link>https://iczelia.net/blog/linalg-apl/</link>
       <title>Implementing the Faddeev-LeVerrier algorithm in APL</title>
       <pubDate>Mon, 10 Jan 2022 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
-      <guid>https://palaiologos.rocks/posts/linalg-apl</guid>
+      <guid>https://iczelia.net/blog/linalg-apl/</guid>
       <category>Numeric-Math</category>
       <category>Tutorial</category>
     </item>
     <item>
-      <link>https://palaiologos.rocks/posts/poly-root-apl</link>
+      <link>https://iczelia.net/blog/poly-root-apl/</link>
       <title>Finding roots of a polynomial - numerical methods in APL</title>
       <pubDate>Sun, 09 Jan 2022 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
-      <guid>https://palaiologos.rocks/posts/poly-root-apl</guid>
+      <guid>https://iczelia.net/blog/poly-root-apl/</guid>
       <category>Numeric-Math</category>
       <category>Tutorial</category>
     </item>
     <item>
-      <link>https://palaiologos.rocks/posts/taylor-apl</link>
+      <link>https://iczelia.net/blog/taylor-apl/</link>
       <title>Implementing Taylor Series in APL</title>
       <pubDate>Thu, 06 Jan 2022 15:00:00 GMT</pubDate>
       <description>Kamila Szewczyk</description>
-      <guid>https://palaiologos.rocks/posts/taylor-apl</guid>
+      <guid>https://iczelia.net/blog/taylor-apl/</guid>
       <category>Numeric-Math</category>
       <category>Tutorial</category>
     </item>


### PR DESCRIPTION
Kamila Szewczyk's blog moved from **palaiologos.rocks** to **iczelia.net** (`/posts/<slug>` → `/blog/<slug>`). This updates all **7** existing links and regenerates `rss.xml`.

Every new URL was verified to return HTTP 200:
- polygon-triangulation, dan-baronets-microwave, avg, lc-apl, linalg-apl, poly-root-apl, taylor-apl

No articles added or removed (still 190); this is purely a link migration. Trailing slash normalised to iczelia's canonical form.

This is the follow-up to #21, whose source checker already tracks the new domain via `iczelia.net/blog/tag/apl/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)